### PR TITLE
Add test utilities for telegram webhook testing

### DIFF
--- a/src/test/kotlin/com/example/app/testutil/Fakes.kt
+++ b/src/test/kotlin/com/example/app/testutil/Fakes.kt
@@ -1,0 +1,87 @@
+package com.example.app.testutil
+
+import com.example.app.telegram.UpdateSink
+import com.example.app.telegram.dto.UpdateDto
+import com.example.giftsbot.telegram.ChatDto
+import com.example.giftsbot.telegram.MessageDto
+import com.example.giftsbot.telegram.UserDto
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+class RecordingSink : UpdateSink {
+    private val queue = ConcurrentLinkedQueue<UpdateDto>()
+    private val calls = AtomicInteger(0)
+
+    override suspend fun enqueue(update: UpdateDto) {
+        calls.incrementAndGet()
+        queue.add(update)
+    }
+
+    fun enqueueCalls(): Int = calls.get()
+
+    fun recordedUpdates(): List<UpdateDto> = queue.toList()
+
+    fun drain(): List<UpdateDto> {
+        val drained = mutableListOf<UpdateDto>()
+        while (true) {
+            val next = queue.poll() ?: break
+            drained += next
+        }
+        return drained
+    }
+
+    fun reset() {
+        queue.clear()
+        calls.set(0)
+    }
+
+    fun isEmpty(): Boolean = queue.isEmpty()
+}
+
+object JsonSamples {
+    private val json =
+        Json {
+            encodeDefaults = true
+            explicitNulls = false
+        }
+
+    private const val BASE_TIMESTAMP = 1_700_000_000L
+
+    fun singleUpdate(id: Long): String = json.encodeToString(UpdateDto.serializer(), sampleUpdateDto(id))
+
+    fun batch(vararg ids: Long): String {
+        val updates = ids.map(::sampleUpdateDto)
+        return json.encodeToString(ListSerializer(UpdateDto.serializer()), updates)
+    }
+
+    fun dto(id: Long): UpdateDto = sampleUpdateDto(id)
+
+    fun dtos(vararg ids: Long): List<UpdateDto> = ids.map(::sampleUpdateDto)
+
+    private fun sampleUpdateDto(id: Long): UpdateDto =
+        UpdateDto(
+            update_id = id,
+            message =
+                MessageDto(
+                    message_id = id * 10,
+                    date = BASE_TIMESTAMP + id,
+                    chat =
+                        ChatDto(
+                            id = id * 100,
+                            type = "private",
+                            username = "test$id",
+                        ),
+                    from =
+                        UserDto(
+                            id = id * 1_000,
+                            is_bot = false,
+                            first_name = "Tester$id",
+                            username = "tester$id",
+                        ),
+                    text = "update-$id",
+                ),
+        )
+}

--- a/src/test/kotlin/com/example/app/testutil/TestApp.kt
+++ b/src/test/kotlin/com/example/app/testutil/TestApp.kt
@@ -1,0 +1,90 @@
+package com.example.app.testutil
+
+import com.example.app.plugins.installCallIdPlugin
+import com.example.app.plugins.installJsonSerialization
+import com.example.app.plugins.installMicrometerMetrics
+import com.example.app.telegram.UpdateSink
+import com.example.app.telegram.adminTelegramWebhookRoutes
+import com.example.app.telegram.telegramWebhookRoutes
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.ktor.server.application.Application
+import io.ktor.server.application.pluginOrNull
+import io.ktor.server.metrics.micrometer.MicrometerMetrics
+import io.ktor.server.plugins.callid.CallId
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.util.AttributeKey
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+private val meterRegistryAttribute = AttributeKey<PrometheusMeterRegistry>("test-app-prometheus")
+
+fun Application.testWebhook(
+    secret: String,
+    sink: UpdateSink,
+    path: String = "/tghook",
+) {
+    require(secret.isNotBlank()) { "secret must not be blank" }
+    require(path.isNotBlank()) { "path must not be blank" }
+    val registry = ensureTestPlugins()
+    routing {
+        telegramWebhookRoutes(
+            webhookPath = path,
+            expectedSecretToken = secret,
+            sink = sink,
+            meterRegistry = registry,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+fun Application.testAdmin(
+    api: TelegramApiClient,
+    adminToken: String,
+    publicBaseUrl: String,
+    webhookPath: String,
+    webhookSecret: String,
+) {
+    require(adminToken.isNotBlank()) { "adminToken must not be blank" }
+    require(publicBaseUrl.isNotBlank()) { "publicBaseUrl must not be blank" }
+    require(webhookPath.isNotBlank()) { "webhookPath must not be blank" }
+    require(webhookSecret.isNotBlank()) { "webhookSecret must not be blank" }
+    val registry = ensureTestPlugins()
+    routing {
+        adminTelegramWebhookRoutes(
+            adminToken = adminToken,
+            telegramApiClient = api,
+            publicBaseUrl = publicBaseUrl,
+            webhookPath = webhookPath,
+            webhookSecretToken = webhookSecret,
+            meterRegistry = registry,
+        )
+    }
+}
+
+private fun Application.ensureTestPlugins(): PrometheusMeterRegistry {
+    if (pluginOrNull(ContentNegotiation) == null) {
+        installJsonSerialization()
+    }
+    if (pluginOrNull(CallId) == null) {
+        installCallIdPlugin()
+    }
+    if (attributes.contains(meterRegistryAttribute)) {
+        return attributes[meterRegistryAttribute]
+    }
+    val registry = findExistingPrometheusRegistry() ?: installMicrometerMetrics()
+    attributes.put(meterRegistryAttribute, registry)
+    return registry
+}
+
+private fun Application.findExistingPrometheusRegistry(): PrometheusMeterRegistry? {
+    val pluginInstance = pluginOrNull(MicrometerMetrics) ?: return null
+    val registry =
+        pluginInstance.javaClass.declaredFields
+            .firstOrNull { field -> MeterRegistry::class.java.isAssignableFrom(field.type) }
+            ?.let { field ->
+                field.isAccessible = true
+                field.get(pluginInstance)
+            }
+    return registry as? PrometheusMeterRegistry
+}


### PR DESCRIPTION
## Summary
- add RecordingSink test fake to collect updates and sample JSON payload helpers
- provide Application extensions to bootstrap webhook and admin routes with baseline plugins in tests

## Testing
- ./gradlew clean build test detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d2ad64483c832196e1f991be5e57c2