### PR TITLE
Fix UpdateDispatcher shutdown and ktlint issues

### DIFF
--- a/src/test/kotlin/com/example/app/telegram/UpdateDispatcherTest.kt
+++ b/src/test/kotlin/com/example/app/telegram/UpdateDispatcherTest.kt
@@ -9,131 +9,134 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpdateDispatcherTest {
+    @Test
+    fun `single update is enqueued and processed`() =
+        runTest(UnconfinedTestDispatcher()) {
+            resetMetrics()
+            val meterRegistry = SimpleMeterRegistry()
+            val dispatcher =
+                UpdateDispatcher(
+                    scope = this,
+                    meterRegistry = meterRegistry,
+                    queueCapacity = 4,
+                )
+
+            try {
+                dispatcher.start()
+
+                dispatcher.enqueue(JsonSamples.dto(1))
+
+                dispatcher.close()
+
+                assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_ENQUEUED_TOTAL))
+                assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_PROCESSED_TOTAL))
+                assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DUPLICATED_TOTAL))
+                assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL))
+            } finally {
+                dispatcher.close()
+            }
+        }
 
     @Test
-    fun `single update is enqueued and processed`() = runTest(UnconfinedTestDispatcher()) {
-        resetMetrics()
-        val meterRegistry = SimpleMeterRegistry()
-        val dispatcher =
-            UpdateDispatcher(
-                scope = this,
-                meterRegistry = meterRegistry,
-                queueCapacity = 4,
-            )
+    fun `duplicate update is not enqueued`() =
+        runTest(UnconfinedTestDispatcher()) {
+            resetMetrics()
+            val meterRegistry = SimpleMeterRegistry()
+            val dispatcher =
+                UpdateDispatcher(
+                    scope = this,
+                    meterRegistry = meterRegistry,
+                    queueCapacity = 4,
+                )
 
-        try {
+            try {
+                dispatcher.start()
+
+                val update = JsonSamples.dto(2)
+                dispatcher.enqueue(update)
+                dispatcher.enqueue(update)
+
+                dispatcher.close()
+
+                assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_ENQUEUED_TOTAL))
+                assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_PROCESSED_TOTAL))
+                assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DUPLICATED_TOTAL))
+                assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL))
+            } finally {
+                dispatcher.close()
+            }
+        }
+
+    @Test
+    fun `queue overflow drops exactly one update`() =
+        runTest(UnconfinedTestDispatcher()) {
+            resetMetrics()
+            val meterRegistry = SimpleMeterRegistry()
+            val dispatcher =
+                UpdateDispatcher(
+                    scope = this,
+                    meterRegistry = meterRegistry,
+                    queueCapacity = 2,
+                )
+
+            try {
+                dispatcher.enqueue(JsonSamples.dto(10))
+                dispatcher.enqueue(JsonSamples.dto(11))
+                dispatcher.enqueue(JsonSamples.dto(12))
+
+                dispatcher.start()
+                dispatcher.close()
+
+                assertEquals(3.0, meterRegistry.queueCounter(MetricsNames.UPDATES_ENQUEUED_TOTAL))
+                assertEquals(2.0, meterRegistry.queueCounter(MetricsNames.UPDATES_PROCESSED_TOTAL))
+                assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DUPLICATED_TOTAL))
+                assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL))
+            } finally {
+                dispatcher.close()
+            }
+        }
+
+    @Test
+    fun `close completes workers and cleanup job`() =
+        runTest(UnconfinedTestDispatcher()) {
+            resetMetrics()
+            val meterRegistry = SimpleMeterRegistry()
+            val parentJob = SupervisorJob()
+            val scope = CoroutineScope(parentJob)
+            val dispatcher =
+                UpdateDispatcher(
+                    scope = scope,
+                    meterRegistry = meterRegistry,
+                    queueCapacity = 4,
+                    workers = 2,
+                )
+
+            val dropBeforeStart = meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL)
+
             dispatcher.start()
+            dispatcher.enqueue(JsonSamples.dto(20))
 
-            dispatcher.enqueue(JsonSamples.dto(1))
+            withTimeout(5_000) {
+                dispatcher.close()
+            }
 
-            dispatcher.close()
+            assertTrue(parentJob.children.none())
 
-            assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_ENQUEUED_TOTAL))
-            assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_PROCESSED_TOTAL))
-            assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DUPLICATED_TOTAL))
-            assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL))
-        } finally {
-            dispatcher.close()
+            dispatcher.enqueue(JsonSamples.dto(21))
+            val dropAfterClose = meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL)
+            assertEquals(dropBeforeStart + 1.0, dropAfterClose)
+
+            parentJob.cancel()
         }
-    }
-
-    @Test
-    fun `duplicate update is not enqueued`() = runTest(UnconfinedTestDispatcher()) {
-        resetMetrics()
-        val meterRegistry = SimpleMeterRegistry()
-        val dispatcher =
-            UpdateDispatcher(
-                scope = this,
-                meterRegistry = meterRegistry,
-                queueCapacity = 4,
-            )
-
-        try {
-            dispatcher.start()
-
-            val update = JsonSamples.dto(2)
-            dispatcher.enqueue(update)
-            dispatcher.enqueue(update)
-
-            dispatcher.close()
-
-            assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_ENQUEUED_TOTAL))
-            assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_PROCESSED_TOTAL))
-            assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DUPLICATED_TOTAL))
-            assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL))
-        } finally {
-            dispatcher.close()
-        }
-    }
-
-    @Test
-    fun `queue overflow drops exactly one update`() = runTest(UnconfinedTestDispatcher()) {
-        resetMetrics()
-        val meterRegistry = SimpleMeterRegistry()
-        val dispatcher =
-            UpdateDispatcher(
-                scope = this,
-                meterRegistry = meterRegistry,
-                queueCapacity = 2,
-            )
-
-        try {
-            dispatcher.enqueue(JsonSamples.dto(10))
-            dispatcher.enqueue(JsonSamples.dto(11))
-            dispatcher.enqueue(JsonSamples.dto(12))
-
-            dispatcher.start()
-            dispatcher.close()
-
-            assertEquals(3.0, meterRegistry.queueCounter(MetricsNames.UPDATES_ENQUEUED_TOTAL))
-            assertEquals(2.0, meterRegistry.queueCounter(MetricsNames.UPDATES_PROCESSED_TOTAL))
-            assertEquals(0.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DUPLICATED_TOTAL))
-            assertEquals(1.0, meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL))
-        } finally {
-            dispatcher.close()
-        }
-    }
-
-    @Test
-    fun `close completes workers and cleanup job`() = runTest(UnconfinedTestDispatcher()) {
-        resetMetrics()
-        val meterRegistry = SimpleMeterRegistry()
-        val parentJob = SupervisorJob()
-        val scope = CoroutineScope(parentJob)
-        val dispatcher =
-            UpdateDispatcher(
-                scope = scope,
-                meterRegistry = meterRegistry,
-                queueCapacity = 4,
-                workers = 2,
-            )
-
-        val dropBeforeStart = meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL)
-
-        dispatcher.start()
-        dispatcher.enqueue(JsonSamples.dto(20))
-
-        withTimeout(5_000) {
-            dispatcher.close()
-        }
-
-        assertTrue(parentJob.children.none())
-
-        dispatcher.enqueue(JsonSamples.dto(21))
-        val dropAfterClose = meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL)
-        assertEquals(dropBeforeStart + 1.0, dropAfterClose)
-
-        parentJob.cancel()
-    }
 
     private fun MeterRegistry.queueCounter(name: String): Double =
         Metrics

--- a/src/test/kotlin/com/example/app/telegram/WebhookParsingAndSizeTest.kt
+++ b/src/test/kotlin/com/example/app/telegram/WebhookParsingAndSizeTest.kt
@@ -132,7 +132,10 @@ private fun Application.stubJsonErrorResponses() {
     }
 }
 
-private suspend fun awaitEnqueueCalls(sink: RecordingSink, expectedCalls: Int) {
+private suspend fun awaitEnqueueCalls(
+    sink: RecordingSink,
+    expectedCalls: Int,
+) {
     withTimeout(1_000) {
         while (sink.enqueueCalls() < expectedCalls) {
             delay(10)

--- a/src/test/kotlin/com/example/app/testutil/TestApp.kt
+++ b/src/test/kotlin/com/example/app/testutil/TestApp.kt
@@ -85,7 +85,7 @@ private fun Application.findExistingPrometheusRegistry(): PrometheusMeterRegistr
             ?.let { field ->
                 field.isAccessible = true
                 field.get(pluginInstance)
-    }
+            }
     return registry as? PrometheusMeterRegistry
 }
 

--- a/src/test/kotlin/com/example/giftsbot/telegram/LongPollingRunnerTest.kt
+++ b/src/test/kotlin/com/example/giftsbot/telegram/LongPollingRunnerTest.kt
@@ -1,0 +1,260 @@
+package com.example.giftsbot.telegram
+
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.app.telegram.UpdateSink
+import com.example.app.telegram.dto.UpdateDto
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.coVerifySequence
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LongPollingRunnerTest {
+    private val meterRegistry = SimpleMeterRegistry()
+    private val defaultAllowedUpdates = TelegramApiClient.AllowedUpdates.DEFAULT
+
+    @AfterAll
+    fun tearDown() {
+        meterRegistry.close()
+    }
+
+    @Test
+    fun `start removes webhook before polling`() {
+        runTest {
+            val api = mockk<TelegramApiClient>()
+            val sink = mockk<UpdateSink>(relaxUnitFun = true)
+            val (runner, runnerScope) = createRunner(testScheduler, api, sink)
+
+            val firstPollStarted = CompletableDeferred<Unit>()
+            coEvery { api.deleteWebhook(false) } returns true
+            coEvery { api.getUpdates(any(), any(), any()) }
+                .coAnswers {
+                    firstPollStarted.complete(Unit)
+                    awaitCancellation()
+                }
+
+            val job = runner.start()
+            firstPollStarted.await()
+
+            coVerifyOrder {
+                api.deleteWebhook(false)
+                api.getUpdates(null, 25, defaultAllowedUpdates)
+            }
+
+            runner.stop()
+            assertTrue(job.isCompleted)
+            runnerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `offset advances after batches`() {
+        runTest {
+            val api = mockk<TelegramApiClient>()
+            val sink = mockk<UpdateSink>(relaxUnitFun = true)
+            val (runner, runnerScope) = createRunner(testScheduler, api, sink)
+
+            val thirdCallStarted = CompletableDeferred<Unit>()
+            val firstBatch = listOf(update(10), update(11))
+            val secondBatch = listOf(update(12))
+
+            coEvery { api.deleteWebhook(false) } returns true
+            var callIndex = 0
+            coEvery { api.getUpdates(any(), any(), any()) }
+                .coAnswers {
+                    when (callIndex++) {
+                        0 -> {
+                            assertNull(firstArg())
+                            assertEquals(25, secondArg())
+                            assertEquals(defaultAllowedUpdates, thirdArg())
+                            firstBatch
+                        }
+
+                        1 -> {
+                            assertEquals(12L, firstArg())
+                            assertEquals(25, secondArg())
+                            assertEquals(defaultAllowedUpdates, thirdArg())
+                            secondBatch
+                        }
+
+                        2 -> {
+                            assertEquals(13L, firstArg())
+                            assertEquals(25, secondArg())
+                            assertEquals(defaultAllowedUpdates, thirdArg())
+                            thirdCallStarted.complete(Unit)
+                            awaitCancellation()
+                        }
+
+                        else -> error("Unexpected poll invocation")
+                    }
+                }
+
+            val job = runner.start()
+            thirdCallStarted.await()
+
+            coVerifySequence {
+                sink.enqueue(firstBatch[0])
+                sink.enqueue(firstBatch[1])
+                sink.enqueue(secondBatch[0])
+            }
+
+            runner.stop()
+            assertTrue(job.isCompleted)
+            runnerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `retriable failures are retried and counted`() {
+        runTest {
+            val api = mockk<TelegramApiClient>()
+            val sink = mockk<UpdateSink>(relaxUnitFun = true)
+            val (runner, runnerScope) = createRunner(testScheduler, api, sink)
+
+            val fourthAttemptStarted = CompletableDeferred<Unit>()
+            coEvery { api.deleteWebhook(false) } returns true
+            var attempts = 0
+            coEvery { api.getUpdates(any(), any(), any()) }
+                .coAnswers {
+                    attempts += 1
+                    when (attempts) {
+                        1, 2, 3 -> throw IOException("boom $attempts")
+                        4 -> {
+                            fourthAttemptStarted.complete(Unit)
+                            awaitCancellation()
+                        }
+
+                        else -> error("Unexpected attempt $attempts")
+                    }
+                }
+
+            val retriesCounter = counter(MetricsNames.LP_RETRIES_TOTAL)
+            val errorsCounter = counter(MetricsNames.LP_ERRORS_total)
+            val retriesBefore = retriesCounter.count()
+            val errorsBefore = errorsCounter.count()
+
+            val job = runner.start()
+            advanceUntilIdle()
+            fourthAttemptStarted.await()
+
+            assertEquals(retriesBefore + 3.0, retriesCounter.count())
+            assertEquals(errorsBefore, errorsCounter.count())
+            coVerify(exactly = 4) { api.getUpdates(any(), any(), any()) }
+
+            runner.stop()
+            assertTrue(job.isCompleted)
+            runnerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `non retriable failure increments error counter without retry`() {
+        runTest {
+            val api = mockk<TelegramApiClient>()
+            val sink = mockk<UpdateSink>(relaxUnitFun = true)
+            val (runner, runnerScope) = createRunner(testScheduler, api, sink)
+
+            coEvery { api.deleteWebhook(false) } returns true
+            val clientError = clientErrorException()
+            coEvery { api.getUpdates(any(), any(), any()) } throws clientError
+
+            val retriesCounter = counter(MetricsNames.LP_RETRIES_TOTAL)
+            val errorsCounter = counter(MetricsNames.LP_ERRORS_total)
+            val retriesBefore = retriesCounter.count()
+            val errorsBefore = errorsCounter.count()
+
+            val job = runner.start()
+            advanceUntilIdle()
+
+            assertTrue(job.isCancelled)
+            assertEquals(retriesBefore, retriesCounter.count())
+            assertEquals(errorsBefore + 1.0, errorsCounter.count())
+            coVerify(exactly = 1) { api.getUpdates(any(), any(), any()) }
+
+            runner.stop()
+            runnerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `stop cancels running job`() {
+        runTest {
+            val api = mockk<TelegramApiClient>()
+            val sink = mockk<UpdateSink>(relaxUnitFun = true)
+            val (runner, runnerScope) = createRunner(testScheduler, api, sink)
+
+            val pollStarted = CompletableDeferred<Unit>()
+            coEvery { api.deleteWebhook(false) } returns true
+            coEvery { api.getUpdates(any(), any(), any()) }
+                .coAnswers {
+                    pollStarted.complete(Unit)
+                    awaitCancellation()
+                }
+
+            val job = runner.start()
+            pollStarted.await()
+
+            runner.stop()
+
+            assertTrue(job.isCompleted)
+            coVerify(exactly = 1) { api.getUpdates(any(), any(), any()) }
+
+            runnerScope.cancel()
+        }
+    }
+
+    private fun createRunner(
+        scheduler: TestCoroutineScheduler,
+        api: TelegramApiClient,
+        sink: UpdateSink,
+    ): Pair<LongPollingRunner, TestScope> {
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val scope = TestScope(SupervisorJob() + dispatcher)
+        val runner =
+            LongPollingRunner(
+                api = api,
+                sink = sink,
+                scope = scope,
+                meterRegistry = meterRegistry,
+            )
+        return runner to scope
+    }
+
+    private fun counter(name: String): Counter = meterRegistry.get(name).tag(MetricsTags.COMPONENT, "lp").counter()
+
+    private fun update(id: Long): UpdateDto = UpdateDto(update_id = id)
+
+    private fun clientErrorException(): ClientRequestException {
+        val exception = mockk<ClientRequestException>()
+        val response = mockk<HttpResponse>()
+        every { exception.response } returns response
+        every { response.status } returns HttpStatusCode.BadRequest
+        return exception
+    }
+}


### PR DESCRIPTION
## Summary
- ensure UpdateDispatcher tracks worker completion with atomic state and waits for shutdown without hanging
- wire coroutine exception handlers for workers/cleanup and simplify enqueue logic
- apply ktlint formatting to coroutine tests and helpers

## Testing
- `./gradlew clean build test detekt ktlintCheck --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d3d8d104288321941910d9f9fc6ec9