### PR TITLE
Add Kaml dependency and seed case catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
 
     implementation(libs.dotenv.kotlin)
     implementation(libs.snakeyaml)
+    implementation(libs.kaml)
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.2.20"
 ktor = "3.3.0"
 coroutines = "1.10.2"
 serialization = "1.9.0"
+kaml = "0.96.0"
 slf4j = "2.0.17"
 logback = "1.5.18"
 micrometer = "1.15.1"
@@ -51,6 +52,7 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/resources/cases.yaml
+++ b/src/main/resources/cases.yaml
@@ -1,77 +1,167 @@
 cases:
-  - id: "starter_pack"
-    title: "Стартовый набор идей"
-    price_stars: 29
-    thumbnail: "https://cdn.gifts-bot.dev/cases/starter-pack.png"
-    short_description: "Быстрый запуск рассылки и welcome-флоу с готовыми скриптами."
-    economy:
-      rtp_ext: 0.44
-      jackpot_share: 0.04
-      pity_timer: 12
-    rewards:
-      - type: "gift"
-        name: "Стикер-пак"
-        weight: 0.52
-      - type: "gift"
-        name: "Мини-курс по прогреву"
-        weight: 0.32
-      - type: "premium"
-        months: 1
-        weight: 0.16
-  - id: "premium_launch"
-    title: "Премиальный запуск"
-    price_stars: 99
-    thumbnail: "https://cdn.gifts-bot.dev/cases/premium-launch.png"
-    short_description: "Полный сценарий прогрева с VIP-предложениями и бонусами."
-    economy:
-      rtp_ext: 0.48
-      jackpot_share: 0.05
-      pity_timer: 18
-    rewards:
-      - type: "gift"
-        name: "Telegram Premium 3 месяца"
-        weight: 0.18
-      - type: "gift"
-        name: "Сертификат на рассылку"
-        weight: 0.54
-      - type: "jackpot"
-        name: "Зимний розыгрыш"
-        weight: 0.28
-  - id: "loyalty_drive"
-    title: "Программа лояльности"
-    price_stars: 299
-    thumbnail: "https://cdn.gifts-bot.dev/cases/loyalty-drive.png"
-    short_description: "Автоматизация повторных продаж и персональных бонусов."
-    economy:
-      rtp_ext: 0.5
-      jackpot_share: 0.06
-      pity_timer: 20
-    rewards:
-      - type: "gift"
-        name: "Premium 6 месяцев"
-        weight: 0.15
-      - type: "gift"
-        name: "500 XTR cashback"
-        weight: 0.45
-      - type: "jackpot"
-        name: "Золотой розыгрыш"
-        weight: 0.4
-  - id: "vip_jackpot"
-    title: "VIP-джекпот"
-    price_stars: 999
-    thumbnail: "https://cdn.gifts-bot.dev/cases/vip-jackpot.png"
-    short_description: "Эксклюзивные призы и крупные джекпоты для топовых клиентов."
-    economy:
-      rtp_ext: 0.38
-      jackpot_share: 0.08
-      pity_timer: 25
-    rewards:
-      - type: "gift"
-        name: "Premium 12 месяцев"
-        weight: 0.22
-      - type: "gift"
-        name: "Мерч-коллекция"
-        weight: 0.38
-      - type: "jackpot"
-        name: "Кейс Supernova"
-        weight: 0.4
+  - id: "micro"
+    priceStars: 29
+    rtpExtMin: 0.35
+    rtpExtMax: 0.42
+    jackpotAlpha: 0.012
+    items:
+      - id: "micro-premium-3m"
+        type: PREMIUM_3M
+        starCost: 99
+        probabilityPpm: 8000
+      - id: "micro-gift-campaign-kit"
+        type: GIFT
+        starCost: 49
+        probabilityPpm: 60000
+      - id: "micro-gift-content-pack"
+        type: GIFT
+        starCost: 34
+        probabilityPpm: 120000
+      - id: "micro-gift-onboarding-boost"
+        type: GIFT
+        starCost: 18
+        probabilityPpm: 160000
+      - id: "micro-internal-default"
+        type: INTERNAL
+        probabilityPpm: 652000
+  - id: "bronze"
+    priceStars: 99
+    rtpExtMin: 0.45
+    rtpExtMax: 0.50
+    jackpotAlpha: 0.018
+    items:
+      - id: "bronze-premium-6m"
+        type: PREMIUM_6M
+        starCost: 349
+        probabilityPpm: 15000
+      - id: "bronze-premium-3m"
+        type: PREMIUM_3M
+        starCost: 189
+        probabilityPpm: 60000
+      - id: "bronze-gift-protocols"
+        type: GIFT
+        starCost: 129
+        probabilityPpm: 120000
+      - id: "bronze-gift-growth-sprint"
+        type: GIFT
+        starCost: 89
+        probabilityPpm: 170000
+      - id: "bronze-internal-default"
+        type: INTERNAL
+        probabilityPpm: 635000
+  - id: "silver"
+    priceStars: 299
+    rtpExtMin: 0.47
+    rtpExtMax: 0.53
+    jackpotAlpha: 0.024
+    items:
+      - id: "silver-premium-12m"
+        type: PREMIUM_12M
+        starCost: 599
+        probabilityPpm: 50000
+      - id: "silver-premium-6m"
+        type: PREMIUM_6M
+        starCost: 349
+        probabilityPpm: 90000
+      - id: "silver-premium-3m"
+        type: PREMIUM_3M
+        starCost: 189
+        probabilityPpm: 160000
+      - id: "silver-gift-scale-kit"
+        type: GIFT
+        starCost: 259
+        probabilityPpm: 110000
+      - id: "silver-gift-growth-lab"
+        type: GIFT
+        starCost: 149
+        probabilityPpm: 200000
+      - id: "silver-internal-default"
+        type: INTERNAL
+        probabilityPpm: 390000
+  - id: "gold"
+    priceStars: 999
+    rtpExtMin: 0.42
+    rtpExtMax: 0.50
+    jackpotAlpha: 0.032
+    items:
+      - id: "gold-gift-enterprise-lab"
+        type: GIFT
+        starCost: 1899
+        probabilityPpm: 60000
+      - id: "gold-premium-12m"
+        type: PREMIUM_12M
+        starCost: 599
+        probabilityPpm: 150000
+      - id: "gold-premium-6m"
+        type: PREMIUM_6M
+        starCost: 349
+        probabilityPpm: 180000
+      - id: "gold-gift-scale-bundle"
+        type: GIFT
+        starCost: 999
+        probabilityPpm: 120000
+      - id: "gold-gift-automation-suite"
+        type: GIFT
+        starCost: 749
+        probabilityPpm: 140000
+      - id: "gold-internal-default"
+        type: INTERNAL
+        probabilityPpm: 350000
+  - id: "diamond"
+    priceStars: 2499
+    rtpExtMin: 0.31
+    rtpExtMax: 0.38
+    jackpotAlpha: 0.038
+    items:
+      - id: "diamond-gift-legendary-event"
+        type: GIFT
+        starCost: 4999
+        probabilityPpm: 60000
+      - id: "diamond-premium-12m"
+        type: PREMIUM_12M
+        starCost: 599
+        probabilityPpm: 120000
+      - id: "diamond-premium-6m"
+        type: PREMIUM_6M
+        starCost: 349
+        probabilityPpm: 160000
+      - id: "diamond-gift-automation-studio"
+        type: GIFT
+        starCost: 1899
+        probabilityPpm: 100000
+      - id: "diamond-gift-creative-lab"
+        type: GIFT
+        starCost: 1399
+        probabilityPpm: 140000
+      - id: "diamond-internal-default"
+        type: INTERNAL
+        probabilityPpm: 420000
+  - id: "mythic"
+    priceStars: 4999
+    rtpExtMin: 0.27
+    rtpExtMax: 0.33
+    jackpotAlpha: 0.045
+    items:
+      - id: "mythic-gift-summit-pass"
+        type: GIFT
+        starCost: 8999
+        probabilityPpm: 70000
+      - id: "mythic-premium-12m"
+        type: PREMIUM_12M
+        starCost: 599
+        probabilityPpm: 180000
+      - id: "mythic-premium-6m"
+        type: PREMIUM_6M
+        starCost: 349
+        probabilityPpm: 200000
+      - id: "mythic-gift-strategy-forge"
+        type: GIFT
+        starCost: 2999
+        probabilityPpm: 120000
+      - id: "mythic-gift-concierge"
+        type: GIFT
+        starCost: 4499
+        probabilityPpm: 90000
+      - id: "mythic-internal-default"
+        type: INTERNAL
+        probabilityPpm: 340000


### PR DESCRIPTION
## Summary
- add Kaml YAML parser to the version catalog and server dependencies
- redefine the initial case catalog with six tiers using price, RTP, and jackpot parameters

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68d3fe860e0c8321820cf32ddc2a7e67