### PR TITLE
Add economy case models and validation DTOs

### DIFF
--- a/src/main/kotlin/com/example/giftsbot/economy/CaseModels.kt
+++ b/src/main/kotlin/com/example/giftsbot/economy/CaseModels.kt
@@ -1,0 +1,54 @@
+package com.example.giftsbot.economy
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CaseSlotType {
+    @SerialName("PREMIUM_3M")
+    PREMIUM_3M,
+
+    @SerialName("PREMIUM_6M")
+    PREMIUM_6M,
+
+    @SerialName("PREMIUM_12M")
+    PREMIUM_12M,
+
+    @SerialName("GIFT")
+    GIFT,
+
+    @SerialName("INTERNAL")
+    INTERNAL
+}
+
+@Serializable
+data class PrizeItemConfig(
+    val id: String,
+    val type: CaseSlotType,
+    val starCost: Long? = null,
+    val probabilityPpm: Int
+)
+
+@Serializable
+data class CaseConfig(
+    val id: String,
+    val title: String,
+    val priceStars: Long,
+    val rtpExtMin: Double,
+    val rtpExtMax: Double,
+    val jackpotAlpha: Double,
+    val items: List<PrizeItemConfig>
+)
+
+@Serializable
+data class CasesRoot(
+    val cases: List<CaseConfig>
+)
+
+@Serializable
+data class PublicCaseDto(
+    val id: String,
+    val title: String,
+    val priceStars: Long,
+    val thumbnail: String? = null
+)

--- a/src/main/kotlin/com/example/giftsbot/economy/CaseValidation.kt
+++ b/src/main/kotlin/com/example/giftsbot/economy/CaseValidation.kt
@@ -1,0 +1,21 @@
+package com.example.giftsbot.economy
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CasePreview(
+    val caseId: String,
+    val priceStars: Long,
+    val evExt: Double,
+    val rtpExt: Double,
+    val sumPpm: Int,
+    val alpha: Double
+)
+
+@Serializable
+data class CaseValidationReport(
+    val caseId: String,
+    val isOk: Boolean,
+    val problems: List<String>,
+    val preview: CasePreview
+)


### PR DESCRIPTION
## Summary
- introduce case configuration models with serialization metadata for YAML loading
- add public Mini App case DTO
- define preview and validation report structures for economy cases

## Testing
- ./gradlew --no-daemon compileKotlin

------
https://chatgpt.com/codex/tasks/task_e_68d400a586fc832186afc5c6cc0a744b