### PR TITLE
Add thread-safe cases repository with metrics

### DIFF
--- a/src/main/kotlin/com/example/giftsbot/economy/CasesRepository.kt
+++ b/src/main/kotlin/com/example/giftsbot/economy/CasesRepository.kt
@@ -1,0 +1,116 @@
+package com.example.giftsbot.economy
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsTags
+import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicReference
+
+class CasesRepository(
+    private val meterRegistry: MeterRegistry,
+    private val resourcePath: String = DEFAULT_RESOURCE_PATH,
+    private val loader: (String) -> CasesRoot = CasesYamlLoader::loadFromResources,
+) {
+    private val reloadLock = Any()
+    private val rootRef = AtomicReference(EMPTY_ROOT)
+
+    private val reloadOkCounter =
+        Metrics.counter(meterRegistry, RELOAD_METRIC, MetricsTags.RESULT to RESULT_OK)
+    private val reloadFailCounter =
+        Metrics.counter(meterRegistry, RELOAD_METRIC, MetricsTags.RESULT to RESULT_FAIL)
+    private val validateOkCounter =
+        Metrics.counter(meterRegistry, VALIDATE_METRIC, MetricsTags.RESULT to RESULT_OK)
+    private val validateFailCounter =
+        Metrics.counter(meterRegistry, VALIDATE_METRIC, MetricsTags.RESULT to RESULT_FAIL)
+
+    fun reload(): CasesValidationSummary =
+        synchronized(reloadLock) {
+            runCatching {
+                val loaded = loader(resourcePath)
+                val summary = validateInternal(loaded)
+                rootRef.set(loaded)
+                summary
+            }.onSuccess { summary ->
+                reloadOkCounter.increment()
+                logSummary("Reloaded cases", summary)
+            }.onFailure { error ->
+                reloadFailCounter.increment()
+                logger.error("Failed to reload cases configuration from '{}'", resourcePath, error)
+            }.getOrThrow()
+        }
+
+    fun listPublic(): List<PublicCaseDto> = rootRef.get().cases.map(CasesYamlLoader::toPublic)
+
+    fun getPreview(caseId: String): CasePreview? {
+        val current = rootRef.get()
+        val case = current.cases.firstOrNull { it.id == caseId } ?: return null
+        return CasesYamlLoader.computePreview(case)
+    }
+
+    fun validateAll(): CasesValidationSummary {
+        val summary = validateInternal(rootRef.get())
+        logSummary("Validated cases", summary)
+        return summary
+    }
+
+    private fun validateInternal(root: CasesRoot): CasesValidationSummary {
+        val reports =
+            root.cases.map { case ->
+                val report = CasesYamlLoader.validate(case)
+                if (report.isOk) {
+                    validateOkCounter.increment()
+                } else {
+                    validateFailCounter.increment()
+                    logger.warn(
+                        "Case '{}' failed validation: {}",
+                        report.caseId,
+                        report.problems.joinToString(separator = "; "),
+                    )
+                }
+                report
+            }
+        val okCount = reports.count { it.isOk }
+        val failCount = reports.size - okCount
+        return CasesValidationSummary(
+            total = reports.size,
+            ok = okCount,
+            failed = failCount,
+            reports = reports,
+        )
+    }
+
+    private fun logSummary(
+        action: String,
+        summary: CasesValidationSummary,
+    ) {
+        if (summary.failed == 0) {
+            logger.info("{}: {} total, all passed", action, summary.total)
+        } else {
+            logger.warn(
+                "{}: {} total, {} passed, {} failed",
+                action,
+                summary.total,
+                summary.ok,
+                summary.failed,
+            )
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_RESOURCE_PATH = "config/cases.yaml"
+        private const val RELOAD_METRIC = "economy_reload_total"
+        private const val VALIDATE_METRIC = "economy_validate_total"
+        private const val RESULT_OK = "ok"
+        private const val RESULT_FAIL = "fail"
+
+        private val EMPTY_ROOT = CasesRoot(emptyList())
+        private val logger = LoggerFactory.getLogger(CasesRepository::class.java)
+    }
+}
+
+data class CasesValidationSummary(
+    val total: Int,
+    val ok: Int,
+    val failed: Int,
+    val reports: List<CaseValidationReport>,
+)

--- a/src/main/kotlin/com/example/giftsbot/economy/CasesYamlLoader.kt
+++ b/src/main/kotlin/com/example/giftsbot/economy/CasesYamlLoader.kt
@@ -2,6 +2,7 @@ package com.example.giftsbot.economy
 
 import com.charleskorn.kaml.Yaml
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
 import java.util.Locale
 
 object CasesYamlLoader {
@@ -15,7 +16,10 @@ object CasesYamlLoader {
     fun loadFromResources(path: String = DEFAULT_PATH): CasesRoot {
         val loader = Thread.currentThread().contextClassLoader ?: CasesYamlLoader::class.java.classLoader
         val stream = loader?.getResourceAsStream(path) ?: error("Cases config resource '$path' is not available")
-        return stream.use { input -> Yaml.default.decodeFromStream(CasesRoot.serializer(), input) }
+        return stream.use { input ->
+            val content = input.bufferedReader().use { reader -> reader.readText() }
+            Yaml.default.decodeFromString(CasesRoot.serializer(), content)
+        }
     }
 
     fun computePreview(case: CaseConfig): CasePreview {


### PR DESCRIPTION
## Summary
- add a thread-safe `CasesRepository` with reload, validation, preview, and public listing support backed by an atomic cache
- record Micrometer counters for reload/validation outcomes and expose an aggregated `CasesValidationSummary`
- adjust `CasesYamlLoader` to decode YAML content from a stream-compatible reader

## Testing
- ./gradlew staticCheck

------
https://chatgpt.com/codex/tasks/task_e_68d4094ffe108321b1917c2a32f56fd8