### PR TITLE
Add economy integration bootstrap

### DIFF
--- a/src/main/kotlin/com/example/app/Application.kt
+++ b/src/main/kotlin/com/example/app/Application.kt
@@ -1,5 +1,6 @@
 package com.example.app
 
+import com.example.app.economy.installEconomyIntegration
 import com.example.app.logging.applicationLogger
 import com.example.app.plugins.installCallIdPlugin
 import com.example.app.plugins.installDefaultSecurityHeaders
@@ -10,8 +11,6 @@ import com.example.app.plugins.installStatusPages
 import com.example.app.routes.infrastructureRoutes
 import com.example.app.telegram.installTelegramIntegration
 import com.example.app.util.configValue
-import com.example.giftsbot.economy.CasesRepository
-import com.example.giftsbot.economy.economyRoutes
 import com.typesafe.config.ConfigFactory
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -72,21 +71,11 @@ fun Application.module() {
         )
     }
 
-    val economyAdminToken =
-        configValue(
-            propertyKeys = listOf("economy.admin.token", "economy.adminToken"),
-            envKeys = listOf("ECONOMY_ADMIN_TOKEN"),
-            configKeys = listOf("app.economy.adminToken"),
-        )?.takeUnless { it.isBlank() }
-
-    val casesRepository = CasesRepository(meterRegistry = prometheusRegistry)
-    casesRepository.reload()
-
+    installEconomyIntegration(meterRegistry = prometheusRegistry)
     installTelegramIntegration(meterRegistry = prometheusRegistry)
 
     routing {
         infrastructureRoutes(healthPath, metricsPath, prometheusRegistry)
         registerMiniAppRoutes(miniAppRoot, miniAppIndex)
-        economyRoutes(casesRepository, economyAdminToken)
     }
 }

--- a/src/main/kotlin/com/example/app/economy/EconomyBootstrap.kt
+++ b/src/main/kotlin/com/example/app/economy/EconomyBootstrap.kt
@@ -1,0 +1,18 @@
+package com.example.app.economy
+
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.economy.economyRoutes
+import io.ktor.server.application.Application
+import io.ktor.server.routing.routing
+import io.micrometer.core.instrument.MeterRegistry
+
+fun Application.installEconomyIntegration(meterRegistry: MeterRegistry) {
+    val casesRepository = CasesRepository(meterRegistry = meterRegistry)
+    casesRepository.reload()
+
+    val adminToken = System.getenv("ADMIN_TOKEN")?.takeUnless { it.isBlank() }
+
+    routing {
+        economyRoutes(casesRepository, adminToken)
+    }
+}

--- a/src/main/kotlin/com/example/giftsbot/economy/EconomyRoutes.kt
+++ b/src/main/kotlin/com/example/giftsbot/economy/EconomyRoutes.kt
@@ -30,7 +30,7 @@ fun Route.economyRoutes(
 
     val token = adminToken?.takeUnless { it.isBlank() }
     if (token == null) {
-        logger.warn("ECONOMY_ADMIN_TOKEN is not configured. Economy admin routes will not be registered.")
+        logger.warn("ADMIN_TOKEN is not configured. Economy admin routes will not be registered.")
         return
     }
 


### PR DESCRIPTION
## Summary
- move economy wiring into a dedicated Application.installEconomyIntegration extension
- read the ADMIN_TOKEN env, warm up the cases repository, and register economy routes there
- hook the new bootstrap from Application.module and align the admin warning message

## Testing
- ./gradlew ktlintCheck detekt

------
https://chatgpt.com/codex/tasks/task_e_68d413cf1d948321b20f92016bd4c74a