### PR TITLE
Add integration tests for economy HTTP routes

### DIFF
--- a/src/test/kotlin/com/example/giftsbot/economy/CasesYamlLoaderTest.kt
+++ b/src/test/kotlin/com/example/giftsbot/economy/CasesYamlLoaderTest.kt
@@ -67,25 +67,26 @@ class CasesYamlLoaderTest {
                 rtpExtMin = 0.1,
                 rtpExtMax = 0.2,
                 jackpotAlpha = 0.5,
-                items = listOf(
-                    PrizeItemConfig(
-                        id = "bad-negative",
-                        type = CaseSlotType.GIFT,
-                        starCost = -10,
-                        probabilityPpm = 600_000,
+                items =
+                    listOf(
+                        PrizeItemConfig(
+                            id = "bad-negative",
+                            type = CaseSlotType.GIFT,
+                            starCost = -10,
+                            probabilityPpm = 600_000,
+                        ),
+                        PrizeItemConfig(
+                            id = "bad-high",
+                            type = CaseSlotType.GIFT,
+                            starCost = 1_000,
+                            probabilityPpm = 300_000,
+                        ),
+                        PrizeItemConfig(
+                            id = "bad-internal",
+                            type = CaseSlotType.INTERNAL,
+                            probabilityPpm = 200_001,
+                        ),
                     ),
-                    PrizeItemConfig(
-                        id = "bad-high",
-                        type = CaseSlotType.GIFT,
-                        starCost = 1_000,
-                        probabilityPpm = 300_000,
-                    ),
-                    PrizeItemConfig(
-                        id = "bad-internal",
-                        type = CaseSlotType.INTERNAL,
-                        probabilityPpm = 200_001,
-                    ),
-                ),
             )
 
         val report = CasesYamlLoader.validate(invalidCase)


### PR DESCRIPTION
## Summary
- add comprehensive integration tests for economy public and admin routes, including token protections
- verify economy reload preview responses and metrics in tests
- fix ktlint style issue in CasesYamlLoaderTest

## Testing
- ./gradlew ktlintCheck detekt test

------
https://chatgpt.com/codex/tasks/task_e_68d5186387508321a0906d989de5d47e