### PR TITLE
Add RNG storage abstraction with in-memory and file stores

### DIFF
--- a/src/main/kotlin/com/example/giftsbot/rng/RngStore.kt
+++ b/src/main/kotlin/com/example/giftsbot/rng/RngStore.kt
@@ -1,0 +1,146 @@
+package com.example.giftsbot.rng
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+
+interface RngCommitStore {
+    fun upsertCommit(
+        dayUtc: LocalDate,
+        serverSeedHash: String,
+    ): RngCommitState
+
+    fun getCommit(dayUtc: LocalDate): RngCommitState?
+
+    fun reveal(
+        dayUtc: LocalDate,
+        serverSeed: String,
+    ): RngCommitState?
+
+    fun latestCommitted(): RngCommitState?
+}
+
+interface RngDrawStore {
+    @Suppress("LongParameterList")
+    fun insertIfAbsent(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+        serverSeedHash: String,
+        rollHex: String,
+        ppm: Int,
+        resultItemId: String?,
+    ): RngDrawRecord
+
+    fun findByIdempotency(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+    ): RngDrawRecord?
+
+    fun listByUser(
+        userId: Long,
+        limit: Int,
+        offset: Int,
+    ): List<RngDrawRecord>
+}
+
+internal const val RNG_STORE_TTL_DAYS: Long = 30L
+internal val RNG_STORE_DEFAULT_TTL: Duration = Duration.ofDays(RNG_STORE_TTL_DAYS)
+
+@Serializable
+sealed interface RngCommitState {
+    val dayUtc: LocalDate
+    val serverSeedHash: String
+    val committedAt: Instant
+}
+
+@Serializable
+@SerialName("pending")
+data class RngCommitPending(
+    @Serializable(with = LocalDateIso8601Serializer::class)
+    override val dayUtc: LocalDate,
+    override val serverSeedHash: String,
+    @Serializable(with = InstantIso8601Serializer::class)
+    override val committedAt: Instant,
+) : RngCommitState
+
+@Serializable
+@SerialName("revealed")
+data class RngCommitRevealed(
+    @Serializable(with = LocalDateIso8601Serializer::class)
+    override val dayUtc: LocalDate,
+    override val serverSeedHash: String,
+    @Serializable(with = InstantIso8601Serializer::class)
+    override val committedAt: Instant,
+    val serverSeed: String,
+    @Serializable(with = InstantIso8601Serializer::class)
+    val revealedAt: Instant,
+) : RngCommitState
+
+@Serializable
+data class RngDrawRecord(
+    val caseId: String,
+    val userId: Long,
+    val nonce: String,
+    val serverSeedHash: String,
+    val rollHex: String,
+    val ppm: Int,
+    val resultItemId: String?,
+    @Serializable(with = InstantIso8601Serializer::class)
+    val createdAt: Instant,
+)
+
+data class RngDrawIdempotencyKey(
+    val caseId: String,
+    val userId: Long,
+    val nonce: String,
+)
+
+internal fun RngCommitPending.reveal(
+    serverSeed: String,
+    revealedAt: Instant,
+): RngCommitRevealed =
+    RngCommitRevealed(
+        dayUtc = dayUtc,
+        serverSeedHash = serverSeedHash,
+        committedAt = committedAt,
+        serverSeed = serverSeed,
+        revealedAt = revealedAt,
+    )
+
+object InstantIso8601Serializer : KSerializer<Instant> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("InstantIso8601", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Instant = Instant.parse(decoder.decodeString())
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Instant,
+    ) {
+        encoder.encodeString(value.toString())
+    }
+}
+
+object LocalDateIso8601Serializer : KSerializer<LocalDate> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("LocalDateIso8601", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): LocalDate = LocalDate.parse(decoder.decodeString())
+
+    override fun serialize(
+        encoder: Encoder,
+        value: LocalDate,
+    ) {
+        encoder.encodeString(value.toString())
+    }
+}

--- a/src/main/kotlin/com/example/giftsbot/rng/store/FileRngStore.kt
+++ b/src/main/kotlin/com/example/giftsbot/rng/store/FileRngStore.kt
@@ -1,0 +1,123 @@
+package com.example.giftsbot.rng.store
+
+import com.example.giftsbot.rng.RNG_STORE_DEFAULT_TTL
+import com.example.giftsbot.rng.RngCommitState
+import com.example.giftsbot.rng.RngDrawRecord
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.time.Clock
+import java.time.Duration
+
+private val jsonFormatter: Json =
+    Json {
+        encodeDefaults = true
+        prettyPrint = true
+        classDiscriminator = "type"
+    }
+
+class FileRngStore(
+    private val baseDir: Path,
+    clock: Clock = Clock.systemUTC(),
+    ttl: Duration = RNG_STORE_DEFAULT_TTL,
+) : InMemoryRngStore(clock, ttl) {
+    private val commitsFile: Path = baseDir.resolve("rng_commits.json")
+    private val drawsFile: Path = baseDir.resolve("rng_draws.ndjson")
+    private var loading: Boolean = true
+
+    init {
+        Files.createDirectories(baseDir)
+        loadCommits()
+        loadDraws()
+        cleanupExpiredState()
+        loading = false
+        writeCommitsSnapshot()
+        ensureDrawFile()
+    }
+
+    override fun afterCommitsChanged() {
+        if (!loading) {
+            writeCommitsSnapshot()
+        }
+    }
+
+    override fun afterDrawInserted(record: RngDrawRecord) {
+        if (!loading) {
+            appendDraw(record)
+        }
+    }
+
+    private fun loadCommits() {
+        if (!Files.exists(commitsFile)) {
+            return
+        }
+        val content = Files.readString(commitsFile, StandardCharsets.UTF_8)
+        if (content.isBlank()) {
+            return
+        }
+        val serializer = ListSerializer(RngCommitState.serializer())
+        val states = jsonFormatter.decodeFromString(serializer, content)
+        states.forEach { restoreCommit(it) }
+    }
+
+    private fun loadDraws() {
+        if (!Files.exists(drawsFile)) {
+            return
+        }
+        Files.newBufferedReader(drawsFile, StandardCharsets.UTF_8).useLines { lines ->
+            lines.filter { it.isNotBlank() }.forEach { line ->
+                val record = jsonFormatter.decodeFromString(RngDrawRecord.serializer(), line)
+                restoreDraw(record)
+            }
+        }
+    }
+
+    private fun writeCommitsSnapshot() {
+        val snapshot = commitSnapshot()
+        val serializer = ListSerializer(RngCommitState.serializer())
+        val content = jsonFormatter.encodeToString(serializer, snapshot)
+        writeAtomically(commitsFile, content)
+    }
+
+    private fun appendDraw(record: RngDrawRecord) {
+        val line = jsonFormatter.encodeToString(RngDrawRecord.serializer(), record)
+        Files.writeString(
+            drawsFile,
+            "$line\n",
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND,
+        )
+    }
+
+    private fun writeAtomically(
+        target: Path,
+        content: String,
+    ) {
+        val temp = Files.createTempFile(baseDir, target.fileName.toString(), ".tmp")
+        Files.writeString(temp, content, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING)
+        try {
+            Files.move(
+                temp,
+                target,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING)
+        } catch (_: UnsupportedOperationException) {
+            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private fun ensureDrawFile() {
+        if (!Files.exists(drawsFile)) {
+            Files.writeString(drawsFile, "", StandardCharsets.UTF_8, StandardOpenOption.CREATE)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/giftsbot/rng/store/InMemoryRngStore.kt
+++ b/src/main/kotlin/com/example/giftsbot/rng/store/InMemoryRngStore.kt
@@ -1,0 +1,216 @@
+package com.example.giftsbot.rng.store
+
+import com.example.giftsbot.rng.RNG_STORE_DEFAULT_TTL
+import com.example.giftsbot.rng.RngCommitPending
+import com.example.giftsbot.rng.RngCommitState
+import com.example.giftsbot.rng.RngCommitStore
+import com.example.giftsbot.rng.RngDrawIdempotencyKey
+import com.example.giftsbot.rng.RngDrawRecord
+import com.example.giftsbot.rng.RngDrawStore
+import com.example.giftsbot.rng.reveal
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Suppress("TooManyFunctions")
+open class InMemoryRngStore(
+    private val clock: Clock = Clock.systemUTC(),
+    private val ttl: Duration = RNG_STORE_DEFAULT_TTL,
+) : RngCommitStore,
+    RngDrawStore {
+    protected val commitMap: ConcurrentHashMap<LocalDate, RngCommitState> = ConcurrentHashMap()
+    protected val drawMap: ConcurrentHashMap<RngDrawIdempotencyKey, RngDrawRecord> = ConcurrentHashMap()
+    protected val drawsByUser: ConcurrentHashMap<Long, MutableList<RngDrawRecord>> = ConcurrentHashMap()
+
+    override fun upsertCommit(
+        dayUtc: LocalDate,
+        serverSeedHash: String,
+    ): RngCommitState {
+        val now = clock.instant()
+        cleanupExpiredState(now)
+        var changed = false
+        val updated =
+            commitMap.compute(dayUtc) { _, existing ->
+                when (existing) {
+                    null -> {
+                        changed = true
+                        RngCommitPending(dayUtc, serverSeedHash, now)
+                    }
+                    is RngCommitPending -> {
+                        if (existing.serverSeedHash == serverSeedHash) {
+                            existing
+                        } else {
+                            changed = true
+                            existing.copy(serverSeedHash = serverSeedHash, committedAt = now)
+                        }
+                    }
+                    else -> existing
+                }
+            }
+        if (changed) {
+            afterCommitsChanged()
+        }
+        return requireNotNull(updated)
+    }
+
+    override fun getCommit(dayUtc: LocalDate): RngCommitState? {
+        cleanupExpiredState()
+        return commitMap[dayUtc]
+    }
+
+    override fun reveal(
+        dayUtc: LocalDate,
+        serverSeed: String,
+    ): RngCommitState? {
+        val now = clock.instant()
+        cleanupExpiredState(now)
+        var changed = false
+        val updated =
+            commitMap.computeIfPresent(dayUtc) { _, existing ->
+                when (existing) {
+                    is RngCommitPending -> {
+                        changed = true
+                        existing.reveal(serverSeed, now)
+                    }
+                    else -> existing
+                }
+            }
+        if (changed) {
+            afterCommitsChanged()
+        }
+        return updated
+    }
+
+    override fun latestCommitted(): RngCommitState? {
+        cleanupExpiredState()
+        return commitMap.values.maxByOrNull { it.dayUtc }
+    }
+
+    override fun insertIfAbsent(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+        serverSeedHash: String,
+        rollHex: String,
+        ppm: Int,
+        resultItemId: String?,
+    ): RngDrawRecord {
+        val now = clock.instant()
+        cleanupExpiredState(now)
+        val key = RngDrawIdempotencyKey(caseId, userId, nonce)
+        val record =
+            RngDrawRecord(
+                caseId = caseId,
+                userId = userId,
+                nonce = nonce,
+                serverSeedHash = serverSeedHash,
+                rollHex = rollHex,
+                ppm = ppm,
+                resultItemId = resultItemId,
+                createdAt = now,
+            )
+        val existing = drawMap.putIfAbsent(key, record)
+        if (existing != null) {
+            return existing
+        }
+        val drawsForUser = drawsByUser.computeIfAbsent(userId) { CopyOnWriteArrayList() }
+        drawsForUser.add(record)
+        afterDrawInserted(record)
+        return record
+    }
+
+    override fun findByIdempotency(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+    ): RngDrawRecord? {
+        cleanupExpiredState()
+        return drawMap[RngDrawIdempotencyKey(caseId, userId, nonce)]
+    }
+
+    override fun listByUser(
+        userId: Long,
+        limit: Int,
+        offset: Int,
+    ): List<RngDrawRecord> {
+        require(limit >= 0) { "limit must be non-negative" }
+        require(offset >= 0) { "offset must be non-negative" }
+        cleanupExpiredState()
+        val draws = drawsByUser[userId]?.takeIf { it.isNotEmpty() } ?: return emptyList()
+        val sorted = draws.sortedByDescending { it.createdAt }
+        return if (limit == 0 || offset >= sorted.size) {
+            emptyList()
+        } else {
+            sorted.drop(offset).take(limit)
+        }
+    }
+
+    protected open fun afterCommitsChanged() {
+        // no-op for in-memory variant
+    }
+
+    protected open fun afterDrawInserted(record: RngDrawRecord) {
+        // no-op for in-memory variant
+    }
+
+    protected fun commitSnapshot(): List<RngCommitState> = commitMap.values.sortedBy { it.dayUtc }
+
+    protected fun idempotencyKey(record: RngDrawRecord): RngDrawIdempotencyKey =
+        RngDrawIdempotencyKey(record.caseId, record.userId, record.nonce)
+
+    protected fun restoreCommit(state: RngCommitState) {
+        val now = clock.instant()
+        if (state.committedAt.isBefore(now.minus(ttl))) {
+            return
+        }
+        commitMap[state.dayUtc] = state
+    }
+
+    protected fun restoreDraw(record: RngDrawRecord) {
+        val now = clock.instant()
+        if (record.createdAt.isBefore(now.minus(ttl))) {
+            return
+        }
+        val key = idempotencyKey(record)
+        if (drawMap.putIfAbsent(key, record) == null) {
+            val list = drawsByUser.computeIfAbsent(record.userId) { CopyOnWriteArrayList() }
+            list.add(record)
+        }
+    }
+
+    protected fun cleanupExpiredState(now: Instant = clock.instant()) {
+        cleanupExpired(now)
+    }
+
+    private fun cleanupExpired(now: Instant) {
+        cleanupExpiredCommits(now)
+        cleanupExpiredDraws(now)
+    }
+
+    private fun cleanupExpiredCommits(now: Instant) {
+        val cutoff = now.minus(ttl)
+        commitMap.entries.forEach { (day, commit) ->
+            if (commit.committedAt.isBefore(cutoff)) {
+                commitMap.remove(day, commit)
+            }
+        }
+    }
+
+    private fun cleanupExpiredDraws(now: Instant) {
+        val cutoff = now.minus(ttl)
+        drawMap.entries.forEach { (key, record) ->
+            if (record.createdAt.isBefore(cutoff)) {
+                drawMap.remove(key, record)
+            }
+        }
+        drawsByUser.entries.forEach { (userId, records) ->
+            records.removeIf { it.createdAt.isBefore(cutoff) }
+            if (records.isEmpty()) {
+                drawsByUser.remove(userId, records)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce RNG commit/draw store interfaces and serialization models
- implement the in-memory RNG store with TTL cleanup and idempotent draw tracking
- add a file-backed RNG store that snapshots commits and appends draw records atomically

## Testing
- ./gradlew ktlintCheck detekt --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d52af82f848321a00dd51162bf4772