### PR TITLE
Add receipt builder utility for RNG user proofs

### DIFF
--- a/src/main/kotlin/com/example/giftsbot/rng/RngReceiptBuilder.kt
+++ b/src/main/kotlin/com/example/giftsbot/rng/RngReceiptBuilder.kt
@@ -1,0 +1,31 @@
+package com.example.giftsbot.rng
+
+private const val ROLL_HEX_PREVIEW_LENGTH = 12
+
+fun buildUserReceiptText(
+    receipt: RngReceipt,
+    resultItemId: String?,
+): String {
+    val rollHexPreview = receipt.rollHex.take(ROLL_HEX_PREVIEW_LENGTH)
+    val rollHexShort =
+        if (receipt.rollHex.length > rollHexPreview.length) {
+            "$rollHexPreview…"
+        } else {
+            rollHexPreview
+        }
+
+    return buildString {
+        appendLine("serverSeedHash: ${receipt.serverSeedHash}")
+        appendLine("clientSeed=\"${receipt.clientSeed}\"")
+        appendLine("rollHex: $rollHexShort")
+        appendLine("ppm: ${receipt.ppm}")
+        appendLine("date: ${receipt.date}")
+        append("resultItemId: ${resultItemId ?: "-"}")
+    }
+}
+
+data class RngUserProof(
+    val receipt: RngReceipt,
+    val resultItemId: String?,
+    val verifyUrl: String? = null,
+)


### PR DESCRIPTION
## Summary
- add a helper to format user-facing RNG receipts with the required fields
- introduce the `RngUserProof` model with an optional verify URL placeholder

## Testing
- ./gradlew ktlintCheck detekt

------
https://chatgpt.com/codex/tasks/task_e_68d53b5450f083219b464d9be7254c65