### PR TITLE
Add database-backed RNG store with Jdbi wiring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     implementation(libs.postgresql)
     implementation(libs.jdbi.core)
     implementation(libs.jdbi.sqlobject)
+    implementation(libs.jdbi.kotlin)
+    implementation(libs.jdbi.kotlin.sqlobject)
 
     implementation(libs.dotenv.kotlin)
     implementation(libs.snakeyaml)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 jdbi-core = { module = "org.jdbi:jdbi3-core", version.ref = "jdbi" }
 jdbi-sqlobject = { module = "org.jdbi:jdbi3-sqlobject", version.ref = "jdbi" }
+jdbi-kotlin = { module = "org.jdbi:jdbi3-kotlin", version.ref = "jdbi" }
+jdbi-kotlin-sqlobject = { module = "org.jdbi:jdbi3-kotlin-sqlobject", version.ref = "jdbi" }
 dotenv-kotlin = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/src/main/kotlin/com/example/app/rng/RngBootstrap.kt
+++ b/src/main/kotlin/com/example/app/rng/RngBootstrap.kt
@@ -2,11 +2,23 @@ package com.example.app.rng
 
 import com.example.giftsbot.economy.CasesRepository
 import com.example.giftsbot.rng.RngConfig
+import com.example.giftsbot.rng.SystemEnvReader
 import io.ktor.server.application.Application
 import io.ktor.server.routing.routing
 import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+private val logger = LoggerFactory.getLogger("RngBootstrap")
 
 fun Application.installRngIntegration(meterRegistry: MeterRegistry) {
+    val env = SystemEnvReader
+    val clock = Clock.systemUTC()
+    val storage = RngConfig.resolveStorage(env)
+    logger.info("Initializing RNG storage={}", storage)
+
+    val store = RngConfig.createRngStoreFromEnv(env = env, clock = clock)
+
     val casesRepository = CasesRepository(meterRegistry = meterRegistry)
     casesRepository.reload()
 
@@ -14,9 +26,12 @@ fun Application.installRngIntegration(meterRegistry: MeterRegistry) {
         RngConfig.createService(
             meterRegistry = meterRegistry,
             casesRepository = casesRepository,
+            env = env,
+            clock = clock,
+            store = store,
         )
 
-    val adminToken = System.getenv("ADMIN_TOKEN")?.takeUnless { it.isBlank() }
+    val adminToken = env.get("ADMIN_TOKEN")
 
     routing {
         rngRoutes(

--- a/src/main/kotlin/com/example/giftsbot/data/DataSources.kt
+++ b/src/main/kotlin/com/example/giftsbot/data/DataSources.kt
@@ -1,0 +1,36 @@
+package com.example.giftsbot.data
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
+import javax.sql.DataSource
+
+private const val DEFAULT_POOL_NAME = "giftsbot"
+private const val DEFAULT_MAX_POOL_SIZE = 16
+private const val LEAK_DETECTION_THRESHOLD_MILLIS = 60_000L
+
+fun createHikariDataSource(
+    url: String,
+    user: String,
+    password: String,
+    poolName: String = DEFAULT_POOL_NAME,
+): HikariDataSource {
+    val config = HikariConfig()
+    config.jdbcUrl = url
+    config.username = user
+    config.password = password
+    config.poolName = poolName
+    config.isAutoCommit = false
+    config.maximumPoolSize = DEFAULT_MAX_POOL_SIZE
+    config.transactionIsolation = "TRANSACTION_READ_COMMITTED"
+    config.leakDetectionThreshold = LEAK_DETECTION_THRESHOLD_MILLIS
+    return HikariDataSource(config)
+}
+
+fun createJdbi(dataSource: DataSource): Jdbi =
+    Jdbi.create(dataSource).apply {
+        installPlugin(KotlinPlugin())
+        installPlugin(KotlinSqlObjectPlugin())
+    }

--- a/src/main/kotlin/com/example/giftsbot/rng/RngConfig.kt
+++ b/src/main/kotlin/com/example/giftsbot/rng/RngConfig.kt
@@ -1,6 +1,9 @@
 package com.example.giftsbot.rng
 
+import com.example.giftsbot.data.createHikariDataSource
+import com.example.giftsbot.data.createJdbi
 import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.rng.store.DbRngStore
 import com.example.giftsbot.rng.store.FileRngStore
 import com.example.giftsbot.rng.store.InMemoryRngStore
 import io.micrometer.core.instrument.MeterRegistry
@@ -8,14 +11,27 @@ import java.nio.file.Paths
 import java.time.Clock
 import java.util.Locale
 
+interface RngStore :
+    RngCommitStore,
+    RngDrawStore
+
+fun interface EnvReader {
+    fun get(key: String): String?
+}
+
+object SystemEnvReader : EnvReader {
+    override fun get(key: String): String? = System.getenv(key)?.trim()?.takeUnless { it.isEmpty() }
+}
+
 object RngConfig {
     fun createService(
         meterRegistry: MeterRegistry,
         casesRepository: CasesRepository,
+        env: EnvReader = SystemEnvReader,
         clock: Clock = Clock.systemUTC(),
+        store: RngStore = createRngStoreFromEnv(env, clock),
     ): RngService {
-        val fairnessKey = loadFairnessKey()
-        val store = createStore(clock)
+        val fairnessKey = loadFairnessKey(env)
         return RngService(
             commitStore = store,
             drawStore = store,
@@ -26,29 +42,52 @@ object RngConfig {
         )
     }
 
-    private fun loadFairnessKey(): ByteArray {
-        val rawKey = System.getenv(FAIRNESS_KEY_ENV)?.takeUnless { it.isBlank() }
+    fun createRngStoreFromEnv(
+        env: EnvReader,
+        clock: Clock = Clock.systemUTC(),
+    ): RngStore =
+        when (val storage = resolveStorage(env)) {
+            MEMORY_STORAGE -> wrapStore(InMemoryRngStore(clock))
+            FILE_STORAGE -> {
+                val dir = env.value(RNG_DATA_DIR_ENV) ?: DEFAULT_DATA_DIR
+                wrapStore(FileRngStore(Paths.get(dir), clock))
+            }
+            DB_STORAGE -> createDbStore(env)
+            else -> error("Unsupported RNG_STORAGE value '$storage'")
+        }
+
+    fun resolveStorage(env: EnvReader): String = env.value(RNG_STORAGE_ENV)?.lowercase(Locale.ROOT) ?: MEMORY_STORAGE
+
+    private fun loadFairnessKey(env: EnvReader): ByteArray {
+        val rawKey = env.value(FAIRNESS_KEY_ENV)
         require(rawKey != null) { "FAIRNESS_KEY env variable is required" }
         return decodeFairnessKey(rawKey)
     }
 
-    private fun createStore(clock: Clock): InMemoryRngStore {
-        val storageEnv = System.getenv(RNG_STORAGE_ENV)?.takeUnless { it.isBlank() }
-        val storage = storageEnv?.lowercase(Locale.ROOT) ?: MEMORY_STORAGE
-        return when (storage) {
-            MEMORY_STORAGE -> InMemoryRngStore(clock)
-            FILE_STORAGE -> {
-                val dir = System.getenv(RNG_DATA_DIR_ENV)?.takeUnless { it.isBlank() } ?: DEFAULT_DATA_DIR
-                FileRngStore(Paths.get(dir), clock)
-            }
-            else -> error("Unsupported RNG_STORAGE value '$storage'")
-        }
+    private fun createDbStore(env: EnvReader): RngStore {
+        val url = env.require(DATABASE_URL_ENV)
+        val user = env.require(DATABASE_USER_ENV)
+        val password = env.require(DATABASE_PASSWORD_ENV)
+        val dataSource = createHikariDataSource(url, user, password)
+        val jdbi = createJdbi(dataSource)
+        return DbRngStore(jdbi)
     }
+
+    private fun wrapStore(store: InMemoryRngStore): RngStore =
+        object : RngStore, RngCommitStore by store, RngDrawStore by store {}
+
+    private fun EnvReader.value(key: String): String? = get(key)?.trim()?.takeUnless { it.isEmpty() }
+
+    private fun EnvReader.require(key: String): String = value(key) ?: error("$key env variable is required")
 
     private const val FAIRNESS_KEY_ENV = "FAIRNESS_KEY"
     private const val RNG_STORAGE_ENV = "RNG_STORAGE"
     private const val RNG_DATA_DIR_ENV = "RNG_DATA_DIR"
-    private const val MEMORY_STORAGE = "memory"
-    private const val FILE_STORAGE = "file"
+    const val MEMORY_STORAGE = "memory"
+    const val FILE_STORAGE = "file"
+    const val DB_STORAGE = "db"
+    private const val DATABASE_URL_ENV = "DATABASE_URL"
+    private const val DATABASE_USER_ENV = "DATABASE_USER"
+    private const val DATABASE_PASSWORD_ENV = "DATABASE_PASSWORD"
     private const val DEFAULT_DATA_DIR = "./data"
 }

--- a/src/main/kotlin/com/example/giftsbot/rng/store/DbRngStore.kt
+++ b/src/main/kotlin/com/example/giftsbot/rng/store/DbRngStore.kt
@@ -1,0 +1,256 @@
+package com.example.giftsbot.rng.store
+
+import com.example.giftsbot.rng.RngCommitPending
+import com.example.giftsbot.rng.RngCommitState
+import com.example.giftsbot.rng.RngDrawRecord
+import com.example.giftsbot.rng.RngStore
+import com.example.giftsbot.rng.reveal
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+@Suppress("TooManyFunctions")
+class DbRngStore(
+    private val jdbi: Jdbi,
+) : RngStore {
+    override fun upsertCommit(
+        dayUtc: LocalDate,
+        serverSeedHash: String,
+    ): RngCommitState =
+        jdbi.inTransaction<RngCommitState, Exception> { handle ->
+            handle.insertCommit(dayUtc, serverSeedHash)
+            handle.findCommit(dayUtc) ?: error("Commit for $dayUtc is missing")
+        }
+
+    override fun getCommit(dayUtc: LocalDate): RngCommitState? =
+        jdbi.withHandle<RngCommitState?, Exception> { handle ->
+            handle.findCommit(dayUtc)
+        }
+
+    override fun reveal(
+        dayUtc: LocalDate,
+        serverSeed: String,
+    ): RngCommitState? =
+        jdbi.inTransaction<RngCommitState?, Exception> { handle ->
+            val updated = handle.revealCommit(dayUtc, serverSeed)
+            if (updated) {
+                handle.findCommit(dayUtc) ?: error("Commit for $dayUtc is missing")
+            } else {
+                handle.findCommit(dayUtc)
+            }
+        }
+
+    override fun latestCommitted(): RngCommitState? =
+        jdbi.withHandle<RngCommitState?, Exception> { handle ->
+            handle.findLatestCommit()
+        }
+
+    @Suppress("LongParameterList")
+    override fun insertIfAbsent(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+        serverSeedHash: String,
+        rollHex: String,
+        ppm: Int,
+        resultItemId: String?,
+    ): RngDrawRecord =
+        jdbi.inTransaction<RngDrawRecord, Exception> { handle ->
+            handle.insertDraw(caseId, userId, nonce, serverSeedHash, rollHex, ppm, resultItemId)
+            handle.findDraw(caseId, userId, nonce) ?: error("Draw record is missing")
+        }
+
+    override fun findByIdempotency(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+    ): RngDrawRecord? =
+        jdbi.withHandle<RngDrawRecord?, Exception> { handle ->
+            handle.findDraw(caseId, userId, nonce)
+        }
+
+    override fun listByUser(
+        userId: Long,
+        limit: Int,
+        offset: Int,
+    ): List<RngDrawRecord> {
+        require(limit >= 0) { "limit must be non-negative" }
+        require(offset >= 0) { "offset must be non-negative" }
+        return jdbi.withHandle<List<RngDrawRecord>, Exception> { handle ->
+            handle.listDrawsByUser(userId, limit, offset)
+        }
+    }
+}
+
+private data class DbCommit(
+    val dayUtc: LocalDate,
+    val serverSeedHash: String,
+    val committedAt: Instant,
+    val revealedAt: Instant?,
+    val serverSeed: String?,
+)
+
+private fun Handle.insertCommit(
+    dayUtc: LocalDate,
+    serverSeedHash: String,
+) {
+    createUpdate(
+        """
+        INSERT INTO rng_seed_commits(day_utc, server_seed_hash)
+        VALUES (:dayUtc, :serverSeedHash)
+        ON CONFLICT (day_utc) DO NOTHING
+        """.trimIndent(),
+    ).bind("dayUtc", dayUtc)
+        .bind("serverSeedHash", serverSeedHash)
+        .execute()
+}
+
+private fun Handle.revealCommit(
+    dayUtc: LocalDate,
+    serverSeed: String,
+): Boolean =
+    createUpdate(
+        """
+        UPDATE rng_seed_commits
+        SET server_seed = :serverSeed, revealed_at = now()
+        WHERE day_utc = :dayUtc AND server_seed IS NULL
+        """.trimIndent(),
+    ).bind("dayUtc", dayUtc)
+        .bind("serverSeed", serverSeed)
+        .execute() > 0
+
+@Suppress("LongParameterList")
+private fun Handle.insertDraw(
+    caseId: String,
+    userId: Long,
+    nonce: String,
+    serverSeedHash: String,
+    rollHex: String,
+    ppm: Int,
+    resultItemId: String?,
+) {
+    createUpdate(
+        """
+        INSERT INTO rng_draws(
+            case_id,
+            user_id,
+            nonce,
+            server_seed_hash,
+            roll_hex,
+            ppm,
+            result_item_id
+        ) VALUES (:caseId, :userId, :nonce, :serverSeedHash, :rollHex, :ppm, :resultItemId)
+        ON CONFLICT (case_id, user_id, nonce) DO NOTHING
+        """.trimIndent(),
+    ).bind("caseId", caseId)
+        .bind("userId", userId)
+        .bind("nonce", nonce)
+        .bind("serverSeedHash", serverSeedHash)
+        .bind("rollHex", rollHex)
+        .bind("ppm", ppm)
+        .bind("resultItemId", resultItemId)
+        .execute()
+}
+
+private fun Handle.findCommit(dayUtc: LocalDate): RngCommitState? =
+    createQuery(
+        """
+        SELECT day_utc, server_seed_hash, committed_at, revealed_at, server_seed
+        FROM rng_seed_commits
+        WHERE day_utc = :dayUtc
+        """.trimIndent(),
+    ).bind("dayUtc", dayUtc)
+        .map(::mapCommit)
+        .list()
+        .singleOrNull()
+        ?.toDomain()
+
+private fun Handle.findLatestCommit(): RngCommitState? =
+    createQuery(
+        """
+        SELECT day_utc, server_seed_hash, committed_at, revealed_at, server_seed
+        FROM rng_seed_commits
+        ORDER BY committed_at DESC
+        LIMIT 1
+        """.trimIndent(),
+    ).map(::mapCommit)
+        .list()
+        .singleOrNull()
+        ?.toDomain()
+
+private fun Handle.findDraw(
+    caseId: String,
+    userId: Long,
+    nonce: String,
+): RngDrawRecord? =
+    createQuery(
+        """
+        SELECT case_id, user_id, nonce, server_seed_hash, roll_hex, ppm, result_item_id, created_at
+        FROM rng_draws
+        WHERE case_id = :caseId AND user_id = :userId AND nonce = :nonce
+        """.trimIndent(),
+    ).bind("caseId", caseId)
+        .bind("userId", userId)
+        .bind("nonce", nonce)
+        .map(::mapDraw)
+        .list()
+        .singleOrNull()
+
+private fun Handle.listDrawsByUser(
+    userId: Long,
+    limit: Int,
+    offset: Int,
+): List<RngDrawRecord> =
+    createQuery(
+        """
+        SELECT case_id, user_id, nonce, server_seed_hash, roll_hex, ppm, result_item_id, created_at
+        FROM rng_draws
+        WHERE user_id = :userId
+        ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
+        """.trimIndent(),
+    ).bind("userId", userId)
+        .bind("limit", limit)
+        .bind("offset", offset)
+        .map(::mapDraw)
+        .list()
+
+@Suppress("UnusedParameter")
+private fun mapCommit(
+    resultSet: ResultSet,
+    context: StatementContext,
+): DbCommit =
+    DbCommit(
+        dayUtc = resultSet.getObject("day_utc", LocalDate::class.java),
+        serverSeedHash = resultSet.getString("server_seed_hash"),
+        committedAt = resultSet.getObject("committed_at", OffsetDateTime::class.java).toInstant(),
+        revealedAt = resultSet.getObject("revealed_at", OffsetDateTime::class.java)?.toInstant(),
+        serverSeed = resultSet.getString("server_seed"),
+    )
+
+private fun DbCommit.toDomain(): RngCommitState =
+    if (serverSeed != null && revealedAt != null) {
+        RngCommitPending(dayUtc, serverSeedHash, committedAt).reveal(serverSeed, revealedAt)
+    } else {
+        RngCommitPending(dayUtc, serverSeedHash, committedAt)
+    }
+
+@Suppress("UnusedParameter")
+private fun mapDraw(
+    resultSet: ResultSet,
+    context: StatementContext,
+): RngDrawRecord =
+    RngDrawRecord(
+        caseId = resultSet.getString("case_id"),
+        userId = resultSet.getLong("user_id"),
+        nonce = resultSet.getString("nonce"),
+        serverSeedHash = resultSet.getString("server_seed_hash"),
+        rollHex = resultSet.getString("roll_hex"),
+        ppm = resultSet.getInt("ppm"),
+        resultItemId = resultSet.getString("result_item_id"),
+        createdAt = resultSet.getObject("created_at", OffsetDateTime::class.java).toInstant(),
+    )


### PR DESCRIPTION
## Summary
- add DbRngStore using Jdbi to persist commits and draws
- introduce shared HikariCP/Jdbi factories and expand RNG config to handle db storage
- wire RNG bootstrap to create stores from environment and log selected storage

## Testing
- ./gradlew --console=plain clean build detekt ktlintCheck

------
https://chatgpt.com/codex/tasks/task_e_68d54c01bb8c832186b78a38b87b8dee