### PR TITLE
Add payments configuration and DTO data classes

### DIFF
--- a/src/main/kotlin/com/example/app/payments/PaymentsConfig.kt
+++ b/src/main/kotlin/com/example/app/payments/PaymentsConfig.kt
@@ -1,0 +1,60 @@
+package com.example.app.payments
+
+import com.example.app.util.configValue
+import io.ktor.server.application.Application
+
+const val STARS_CURRENCY_CODE: String = "XTR"
+
+data class PaymentsConfig(
+    val currency: String,
+    val titlePrefix: String?,
+    val receiptEnabled: Boolean,
+    val businessConnectionId: String?,
+)
+
+fun Application.loadPaymentsConfig(): PaymentsConfig {
+    val currency =
+        configValue(
+            propertyKeys = listOf("pay.currency", "payments.currency"),
+            envKeys = listOf("PAY_CURRENCY"),
+            configKeys = listOf("app.payments.currency", "payments.currency"),
+        )?.trim()?.uppercase()?.takeUnless { it.isEmpty() } ?: STARS_CURRENCY_CODE
+
+    require(currency == STARS_CURRENCY_CODE) {
+        "Unsupported payment currency: $currency"
+    }
+
+    val titlePrefix =
+        configValue(
+            propertyKeys = listOf("pay.titlePrefix", "payments.titlePrefix"),
+            envKeys = listOf("PAY_TITLE_PREFIX"),
+            configKeys = listOf("app.payments.titlePrefix", "payments.titlePrefix"),
+        )?.trim()?.takeUnless { it.isEmpty() }
+
+    val receiptEnabled =
+        configValue(
+            propertyKeys = listOf("pay.receiptEnabled", "payments.receiptEnabled"),
+            envKeys = listOf("PAY_RECEIPT_ENABLE"),
+            configKeys = listOf("app.payments.receiptEnabled", "payments.receiptEnabled"),
+        )?.trim()?.lowercase()?.takeUnless { it.isEmpty() }?.let { normalized ->
+            when (normalized) {
+                "true" -> true
+                "false" -> false
+                else -> error("Invalid PAY_RECEIPT_ENABLE value: $normalized")
+            }
+        } ?: false
+
+    val businessConnectionId =
+        configValue(
+            propertyKeys = listOf("pay.businessConnectionId", "payments.businessConnectionId"),
+            envKeys = listOf("PAY_BUSINESS_CONNECTION_ID"),
+            configKeys = listOf("app.payments.businessConnectionId", "payments.businessConnectionId"),
+        )?.trim()?.takeUnless { it.isEmpty() }
+
+    return PaymentsConfig(
+        currency = currency,
+        titlePrefix = titlePrefix,
+        receiptEnabled = receiptEnabled,
+        businessConnectionId = businessConnectionId,
+    )
+}

--- a/src/main/kotlin/com/example/app/payments/dto/PaymentsDtos.kt
+++ b/src/main/kotlin/com/example/app/payments/dto/PaymentsDtos.kt
@@ -1,0 +1,77 @@
+package com.example.app.payments.dto
+
+import com.example.app.payments.STARS_CURRENCY_CODE
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class CreateCaseInvoiceRequest(
+    val caseId: String,
+    val userId: Long,
+    val nonce: String,
+)
+
+@Serializable
+data class CreateCaseInvoiceResponse(
+    val invoiceLink: String,
+    val payload: String,
+)
+
+@Serializable
+data class PaymentPayload(
+    val caseId: String,
+    val userId: Long,
+    val nonce: String,
+    val ts: Long,
+) {
+    init {
+        val encoded = defaultJson.encodeToString(serializer(), this)
+        ensureFits(encoded)
+    }
+
+    fun encode(json: Json = defaultJson): String {
+        val encoded = json.encodeToString(serializer(), this)
+        ensureFits(encoded)
+        return encoded
+    }
+
+    companion object {
+        private const val MAX_PAYLOAD_BYTES: Int = 128
+        private val defaultJson: Json =
+            Json {
+                encodeDefaults = false
+                explicitNulls = false
+            }
+
+        fun decode(
+            raw: String,
+            json: Json = defaultJson,
+        ): PaymentPayload {
+            ensureFits(raw)
+            return json.decodeFromString(serializer(), raw)
+        }
+
+        private fun ensureFits(raw: String) {
+            require(raw.toByteArray(Charsets.UTF_8).size <= MAX_PAYLOAD_BYTES) {
+                "Payment payload size exceeds $MAX_PAYLOAD_BYTES bytes"
+            }
+        }
+    }
+}
+
+@Serializable
+data class PaymentResult(
+    val ok: Boolean,
+    val telegramChargeId: String,
+    val providerChargeId: String? = null,
+    val totalAmount: Long,
+    val currency: String,
+) {
+    init {
+        require(currency == STARS_CURRENCY_CODE) {
+            "Unsupported payment currency: $currency"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a payments configuration loader that reads environment overrides and enforces the Telegram Stars currency
- introduce Kotlin serialization DTOs for invoice creation, payment payload encoding, and payment result validation

## Testing
- ./gradlew clean build test detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d7221a18988321bf174ef480145d5c