### PR TITLE
Add Telegram case invoice creation

### DIFF
--- a/src/main/kotlin/com/example/app/payments/TelegramInvoiceService.kt
+++ b/src/main/kotlin/com/example/app/payments/TelegramInvoiceService.kt
@@ -1,0 +1,86 @@
+package com.example.app.payments
+
+import com.example.app.payments.dto.CreateCaseInvoiceResponse
+import com.example.app.payments.dto.PaymentPayload
+import com.example.giftsbot.economy.CaseConfig
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.telegram.CreateInvoiceLinkRequest
+import com.example.giftsbot.telegram.LabeledPrice
+import com.example.giftsbot.telegram.TelegramApiClient
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+class TelegramInvoiceService(
+    private val casesRepository: CasesRepository,
+    private val telegramApiClient: TelegramApiClient,
+    private val paymentsConfig: PaymentsConfig,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    suspend fun createCaseInvoice(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+    ): CreateCaseInvoiceResponse {
+        val case = caseOrFail(caseId)
+        val payload =
+            PaymentPayload(
+                caseId = caseId,
+                userId = userId,
+                nonce = nonce,
+                ts = clock.instant().toEpochMilli(),
+            )
+        val encodedPayload = payload.encode()
+
+        val title = invoiceTitle(case.title)
+        val description = invoiceDescription(case.title)
+        val prices = listOf(LabeledPrice(label = case.title, amount = case.priceStars))
+
+        logger.info(
+            "Creating case invoice caseId={} userId={} stars={} receiptEnabled={} " +
+                "businessConnection={} payloadSize={}",
+            caseId,
+            userId,
+            case.priceStars,
+            paymentsConfig.receiptEnabled,
+            paymentsConfig.businessConnectionId != null,
+            encodedPayload.length,
+        )
+
+        val invoiceLink =
+            telegramApiClient.createInvoiceLink(
+                CreateInvoiceLinkRequest(
+                    title = title,
+                    description = description,
+                    payload = encodedPayload,
+                    currency = STARS_CURRENCY_CODE,
+                    prices = prices,
+                    businessConnectionId = paymentsConfig.businessConnectionId,
+                    receiptEnabled = paymentsConfig.receiptEnabled.takeIf { it },
+                ),
+            )
+
+        return CreateCaseInvoiceResponse(invoiceLink = invoiceLink, payload = encodedPayload)
+    }
+
+    private fun caseOrFail(caseId: String): CaseConfig =
+        casesRepository.get(caseId)
+            ?: throw IllegalArgumentException("Case '$caseId' is not available")
+
+    private fun invoiceTitle(caseTitle: String): String {
+        val prefix = paymentsConfig.titlePrefix?.trim()?.takeUnless { it.isEmpty() }
+        val combined = listOfNotNull(prefix, caseTitle).joinToString(separator = " ")
+        val normalized = (combined.ifBlank { caseTitle }).trim()
+        return normalized.take(MAX_TITLE_LENGTH)
+    }
+
+    private fun invoiceDescription(caseTitle: String): String {
+        val normalized = caseTitle.trim().ifEmpty { caseTitle }
+        return normalized.take(MAX_DESCRIPTION_LENGTH)
+    }
+
+    companion object {
+        private const val MAX_TITLE_LENGTH = 32
+        private const val MAX_DESCRIPTION_LENGTH = 255
+        private val logger = LoggerFactory.getLogger(TelegramInvoiceService::class.java)
+    }
+}

--- a/src/test/kotlin/com/example/app/payments/TelegramInvoiceServiceTest.kt
+++ b/src/test/kotlin/com/example/app/payments/TelegramInvoiceServiceTest.kt
@@ -1,0 +1,105 @@
+package com.example.app.payments
+
+import com.example.app.payments.dto.PaymentPayload
+import com.example.giftsbot.economy.CaseConfig
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.telegram.CreateInvoiceLinkRequest
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TelegramInvoiceServiceTest {
+    private val clock: Clock = Clock.fixed(Instant.parse("2024-02-03T04:05:06Z"), ZoneOffset.UTC)
+
+    @Test
+    fun `creates invoice link for case`() =
+        runTest {
+            val casesRepository = mockk<CasesRepository>()
+            val telegramApiClient = mockk<TelegramApiClient>()
+            val paymentsConfig =
+                PaymentsConfig(
+                    currency = STARS_CURRENCY_CODE,
+                    titlePrefix = "GiftBot",
+                    receiptEnabled = true,
+                    businessConnectionId = "bc-42",
+                )
+            val service = TelegramInvoiceService(casesRepository, telegramApiClient, paymentsConfig, clock)
+
+            val case =
+                CaseConfig(
+                    id = "micro",
+                    title = "Micro Case",
+                    priceStars = 29,
+                    rtpExtMin = 0.3,
+                    rtpExtMax = 0.4,
+                    jackpotAlpha = 0.01,
+                    items = emptyList(),
+                )
+            every { casesRepository.get("micro") } returns case
+            val requestSlot = slot<CreateInvoiceLinkRequest>()
+            coEvery { telegramApiClient.createInvoiceLink(capture(requestSlot)) } returns
+                "https://t.me/invoice?start=abc"
+
+            val response = service.createCaseInvoice("micro", userId = 1234L, nonce = "nonce123")
+
+            assertEquals("https://t.me/invoice?start=abc", response.invoiceLink)
+            val payload = PaymentPayload.decode(response.payload)
+            assertEquals("micro", payload.caseId)
+            assertEquals(1234L, payload.userId)
+            assertEquals("nonce123", payload.nonce)
+            assertEquals(clock.instant().toEpochMilli(), payload.ts)
+
+            val request = requestSlot.captured
+            assertEquals("GiftBot Micro Case".take(32), request.title)
+            assertEquals("Micro Case", request.description)
+            assertEquals(STARS_CURRENCY_CODE, request.currency)
+            assertEquals(response.payload, request.payload)
+            assertEquals(1, request.prices.size)
+            val price = request.prices.single()
+            assertEquals(case.priceStars, price.amount)
+            assertEquals(case.title, price.label)
+            assertEquals(paymentsConfig.businessConnectionId, request.businessConnectionId)
+            assertEquals(true, request.receiptEnabled)
+            assertNull(request.providerToken)
+
+            coVerify(exactly = 1) { telegramApiClient.createInvoiceLink(any()) }
+        }
+
+    @Test
+    fun `throws when case is missing`() =
+        runTest {
+            val casesRepository = mockk<CasesRepository>()
+            every { casesRepository.get("missing") } returns null
+            val telegramApiClient = mockk<TelegramApiClient>(relaxed = true)
+            val paymentsConfig =
+                PaymentsConfig(
+                    currency = STARS_CURRENCY_CODE,
+                    titlePrefix = null,
+                    receiptEnabled = false,
+                    businessConnectionId = null,
+                )
+            val service = TelegramInvoiceService(casesRepository, telegramApiClient, paymentsConfig, clock)
+
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    service.createCaseInvoice("missing", userId = 1L, nonce = "nonce")
+                }
+            assertTrue(error.message?.contains("missing") == true)
+
+            coVerify(exactly = 0) { telegramApiClient.createInvoiceLink(any()) }
+        }
+}


### PR DESCRIPTION
## Summary
- add a TelegramInvoiceService that builds XTR invoices for case purchases
- extend TelegramApiClient with createInvoiceLink support and related DTOs
- cover invoice creation logic with unit tests

## Testing
- ./gradlew test
- ./gradlew ktlintCheck detekt

------
https://chatgpt.com/codex/tasks/task_e_68d726f791208321b316a0ebc19cfde9