### PR TITLE
Handle Telegram pre-checkout queries

### DIFF
--- a/src/main/kotlin/com/example/app/observability/Metrics.kt
+++ b/src/main/kotlin/com/example/app/observability/Metrics.kt
@@ -38,6 +38,8 @@ object MetricsNames {
     const val ADMIN_DELETE_TOTAL = "tg_admin_webhook_delete_total"
     const val ADMIN_INFO_TOTAL = "tg_admin_webhook_info_total"
     const val ADMIN_FAIL_TOTAL = "tg_admin_webhook_fail_total"
+
+    const val PRE_CHECKOUT_TOTAL = "tg_pre_checkout_total"
 }
 
 object MetricsTags {

--- a/src/main/kotlin/com/example/app/payments/PreCheckoutHandler.kt
+++ b/src/main/kotlin/com/example/app/payments/PreCheckoutHandler.kt
@@ -1,0 +1,169 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.app.payments.dto.PaymentPayload
+import com.example.app.payments.STARS_CURRENCY_CODE
+import com.example.giftsbot.economy.CaseConfig
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.telegram.PreCheckoutQueryDto
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.withTimeout
+import org.slf4j.LoggerFactory
+
+class PreCheckoutHandler(
+    private val telegramApiClient: TelegramApiClient,
+    private val casesRepository: CasesRepository,
+    meterRegistry: MeterRegistry,
+) {
+    private val metrics = PreCheckoutMetrics(meterRegistry)
+
+    suspend fun handle(updateId: Long, query: PreCheckoutQueryDto) =
+        withTimeout(RESPONSE_TIMEOUT_MILLIS) {
+            when (val validation = validate(query)) {
+                is ValidationResult.Success -> respondSuccess(updateId, query, validation)
+                is ValidationResult.Failure -> respondFailure(updateId, query, validation)
+            }
+        }
+
+    private suspend fun respondSuccess(
+        updateId: Long,
+        query: PreCheckoutQueryDto,
+        success: ValidationResult.Success,
+    ) {
+        metrics.markSuccess()
+        logger.info(
+            "pre-checkout approved: updateId={} queryId={} caseId={} userId={} amount={} expectedAmount={}",
+            updateId,
+            query.id,
+            success.payload.caseId,
+            query.from.id,
+            query.total_amount,
+            success.caseConfig.priceStars,
+        )
+        telegramApiClient.answerPreCheckoutQuery(
+            queryId = query.id,
+            ok = true,
+            errorMessage = null,
+        )
+    }
+
+    private suspend fun respondFailure(
+        updateId: Long,
+        query: PreCheckoutQueryDto,
+        failure: ValidationResult.Failure,
+    ) {
+        metrics.markFailure()
+        if (failure.cause != null) {
+            logger.warn(
+                "pre-checkout rejected: updateId={} queryId={} userId={} reason={}",
+                updateId,
+                query.id,
+                query.from.id,
+                failure.reason,
+                failure.cause,
+            )
+        } else {
+            logger.warn(
+                "pre-checkout rejected: updateId={} queryId={} userId={} reason={}",
+                updateId,
+                query.id,
+                query.from.id,
+                failure.reason,
+            )
+        }
+        telegramApiClient.answerPreCheckoutQuery(
+            queryId = query.id,
+            ok = false,
+            errorMessage = failure.userMessage,
+        )
+    }
+
+    private fun validate(query: PreCheckoutQueryDto): ValidationResult {
+        val payloadResult = runCatching { PaymentPayload.decode(query.invoice_payload) }
+        val payload = payloadResult.getOrElse { cause ->
+            return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "invalid_payload",
+                cause = cause,
+            )
+        }
+
+        if (payload.userId != query.from.id) {
+            return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "user_mismatch expected=${payload.userId} actual=${query.from.id}",
+            )
+        }
+        if (payload.nonce.isBlank()) {
+            return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "nonce_blank",
+            )
+        }
+        if (payload.caseId.isBlank()) {
+            return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "case_id_blank",
+            )
+        }
+
+        val case = casesRepository.get(payload.caseId)
+            ?: return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "case_not_found caseId=${payload.caseId}",
+            )
+
+        if (query.currency != STARS_CURRENCY_CODE) {
+            return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "invalid_currency expected=$STARS_CURRENCY_CODE actual=${query.currency}",
+            )
+        }
+        if (query.total_amount != case.priceStars) {
+            return ValidationResult.Failure(
+                userMessage = DEFAULT_ERROR_MESSAGE,
+                reason = "invalid_amount expected=${case.priceStars} actual=${query.total_amount}",
+            )
+        }
+
+        return ValidationResult.Success(payload = payload, caseConfig = case)
+    }
+
+    private class PreCheckoutMetrics(registry: MeterRegistry) {
+        private val componentTag = MetricsTags.COMPONENT to COMPONENT_VALUE
+        private val successCounter =
+            Metrics.counter(registry, MetricsNames.PRE_CHECKOUT_TOTAL, componentTag, MetricsTags.RESULT to RESULT_OK)
+        private val failureCounter =
+            Metrics.counter(registry, MetricsNames.PRE_CHECKOUT_TOTAL, componentTag, MetricsTags.RESULT to RESULT_FAIL)
+
+        fun markSuccess() {
+            successCounter.increment()
+        }
+
+        fun markFailure() {
+            failureCounter.increment()
+        }
+    }
+
+    private sealed interface ValidationResult {
+        data class Success(val payload: PaymentPayload, val caseConfig: CaseConfig) : ValidationResult
+
+        data class Failure(
+            val userMessage: String,
+            val reason: String,
+            val cause: Throwable? = null,
+        ) : ValidationResult
+    }
+
+    companion object {
+        private const val RESPONSE_TIMEOUT_MILLIS = 10_000L
+        private const val COMPONENT_VALUE = "payments"
+        private const val RESULT_OK = "ok"
+        private const val RESULT_FAIL = "fail"
+        private const val DEFAULT_ERROR_MESSAGE = "Payment rejected: invalid parameters."
+        private val logger = LoggerFactory.getLogger(PreCheckoutHandler::class.java)
+    }
+}

--- a/src/main/kotlin/com/example/app/telegram/IncomingUpdate.kt
+++ b/src/main/kotlin/com/example/app/telegram/IncomingUpdate.kt
@@ -2,6 +2,7 @@ package com.example.app.telegram
 
 import com.example.app.telegram.dto.UpdateDto
 import com.example.giftsbot.telegram.MessageDto as MessageDto
+import com.example.giftsbot.telegram.PreCheckoutQueryDto as PreCheckoutQueryDto
 
 sealed interface IncomingUpdate {
     val updateId: Long
@@ -9,6 +10,11 @@ sealed interface IncomingUpdate {
     data class MessageUpdate(
         override val updateId: Long,
         val message: MessageDto,
+    ) : IncomingUpdate
+
+    data class PreCheckoutQueryUpdate(
+        override val updateId: Long,
+        val query: PreCheckoutQueryDto,
     ) : IncomingUpdate
 
     data class RawUpdate(
@@ -20,6 +26,7 @@ sealed interface IncomingUpdate {
 /** Простая адаптация из UpdateDto в IncomingUpdate. Новые типы дополним позже. */
 fun UpdateDto.toIncoming(): IncomingUpdate =
     when {
+        pre_checkout_query != null -> IncomingUpdate.PreCheckoutQueryUpdate(update_id, pre_checkout_query)
         message != null -> IncomingUpdate.MessageUpdate(update_id, message)
         else -> IncomingUpdate.RawUpdate(update_id, this)
     }

--- a/src/main/kotlin/com/example/app/telegram/UpdateDispatcher.kt
+++ b/src/main/kotlin/com/example/app/telegram/UpdateDispatcher.kt
@@ -40,6 +40,7 @@ class UpdateDispatcher(
     private val dedupTtl: Duration = Duration.ofHours(DEFAULT_DEDUP_TTL_HOURS),
     private val workers: Int = 1,
     private val logger: Logger = LoggerFactory.getLogger(UpdateDispatcher::class.java),
+    private val handleUpdate: suspend (IncomingUpdate) -> Unit = { _ -> },
 ) : UpdateSink {
     private val started = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
@@ -210,6 +211,7 @@ class UpdateDispatcher(
             incoming.updateId,
             incoming::class.simpleName,
         )
+        handleUpdate(incoming)
     }
 
     private fun incrementQueueGauge() {

--- a/src/main/kotlin/com/example/app/telegram/WebhookUpdateRouter.kt
+++ b/src/main/kotlin/com/example/app/telegram/WebhookUpdateRouter.kt
@@ -1,0 +1,27 @@
+package com.example.app.telegram
+
+import com.example.app.payments.PreCheckoutHandler
+import org.slf4j.LoggerFactory
+
+class WebhookUpdateRouter(
+    private val preCheckoutHandler: PreCheckoutHandler,
+) {
+    suspend fun route(incoming: IncomingUpdate) {
+        when (incoming) {
+            is IncomingUpdate.PreCheckoutQueryUpdate -> handlePreCheckout(incoming)
+            else -> logger.debug(
+                "no handler for updateId={} type={}",
+                incoming.updateId,
+                incoming::class.simpleName,
+            )
+        }
+    }
+
+    private suspend fun handlePreCheckout(incoming: IncomingUpdate.PreCheckoutQueryUpdate) {
+        preCheckoutHandler.handle(incoming.updateId, incoming.query)
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(WebhookUpdateRouter::class.java)
+    }
+}

--- a/src/test/kotlin/com/example/app/payments/PreCheckoutHandlerTest.kt
+++ b/src/test/kotlin/com/example/app/payments/PreCheckoutHandlerTest.kt
@@ -1,0 +1,176 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.app.payments.dto.PaymentPayload
+import com.example.app.payments.STARS_CURRENCY_CODE
+import com.example.giftsbot.economy.CaseConfig
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.telegram.PreCheckoutQueryDto
+import com.example.giftsbot.telegram.UserDto
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PreCheckoutHandlerTest {
+    private val casesRepository = mockk<CasesRepository>()
+    private val telegramApiClient = mockk<TelegramApiClient>()
+    private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var handler: PreCheckoutHandler
+
+    @BeforeEach
+    fun setUp() {
+        resetMetrics()
+        meterRegistry = SimpleMeterRegistry()
+        handler = PreCheckoutHandler(telegramApiClient, casesRepository, meterRegistry)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (::meterRegistry.isInitialized) {
+            meterRegistry.clear()
+        }
+    }
+
+    @Test
+    fun `answers ok when payload and amount match`() =
+        runTest {
+            val case = caseConfig(price = 299)
+            every { casesRepository.get("silver") } returns case
+            coEvery { telegramApiClient.answerPreCheckoutQuery(any(), any(), any()) } returns true
+
+            val payload =
+                PaymentPayload(
+                    caseId = "silver",
+                    userId = USER_ID,
+                    nonce = "nonce-1",
+                    ts = 123456789L,
+                ).encode()
+            val query =
+                PreCheckoutQueryDto(
+                    id = "pcq-1",
+                    from = userDto(),
+                    currency = STARS_CURRENCY_CODE,
+                    total_amount = case.priceStars,
+                    invoice_payload = payload,
+                )
+
+            handler.handle(updateId = 42L, query = query)
+
+            coVerify(exactly = 1) { telegramApiClient.answerPreCheckoutQuery("pcq-1", true, null) }
+            assertEquals(1.0, counterValue(result = RESULT_OK))
+            assertEquals(0.0, counterValue(result = RESULT_FAIL))
+        }
+
+    @Test
+    fun `rejects when amount differs from case price`() =
+        runTest {
+            val case = caseConfig(price = 999)
+            every { casesRepository.get("gold") } returns case
+            coEvery { telegramApiClient.answerPreCheckoutQuery(any(), any(), any()) } returns true
+
+            val payload =
+                PaymentPayload(
+                    caseId = "gold",
+                    userId = USER_ID,
+                    nonce = "nonce-2",
+                    ts = 987654321L,
+                ).encode()
+            val query =
+                PreCheckoutQueryDto(
+                    id = "pcq-2",
+                    from = userDto(),
+                    currency = STARS_CURRENCY_CODE,
+                    total_amount = case.priceStars + 1,
+                    invoice_payload = payload,
+                )
+
+            handler.handle(updateId = 84L, query = query)
+
+            coVerify(exactly = 1) {
+                telegramApiClient.answerPreCheckoutQuery("pcq-2", false, DEFAULT_ERROR_MESSAGE)
+            }
+            assertEquals(0.0, counterValue(result = RESULT_OK))
+            assertEquals(1.0, counterValue(result = RESULT_FAIL))
+        }
+
+    @Test
+    fun `rejects when payload cannot be decoded`() =
+        runTest {
+            every { casesRepository.get(any()) } returns null
+            coEvery { telegramApiClient.answerPreCheckoutQuery(any(), any(), any()) } returns true
+
+            val query =
+                PreCheckoutQueryDto(
+                    id = "pcq-3",
+                    from = userDto(),
+                    currency = STARS_CURRENCY_CODE,
+                    total_amount = 29,
+                    invoice_payload = "not-a-json",
+                )
+
+            handler.handle(updateId = 126L, query = query)
+
+            coVerify(exactly = 1) {
+                telegramApiClient.answerPreCheckoutQuery("pcq-3", false, DEFAULT_ERROR_MESSAGE)
+            }
+            assertEquals(0.0, counterValue(result = RESULT_OK))
+            assertEquals(1.0, counterValue(result = RESULT_FAIL))
+        }
+
+    private fun counterValue(result: String): Double =
+        Metrics
+            .counter(
+                meterRegistry,
+                MetricsNames.PRE_CHECKOUT_TOTAL,
+                MetricsTags.COMPONENT to COMPONENT_VALUE,
+                MetricsTags.RESULT to result,
+            ).count()
+
+    private fun caseConfig(price: Long): CaseConfig =
+        CaseConfig(
+            id = "ignored",
+            title = "Case",
+            priceStars = price,
+            rtpExtMin = 0.0,
+            rtpExtMax = 0.0,
+            jackpotAlpha = 0.0,
+            items = emptyList(),
+        )
+
+    private fun userDto(): UserDto =
+        UserDto(
+            id = USER_ID,
+            is_bot = false,
+            first_name = "Test",
+        )
+
+    private fun resetMetrics() {
+        val metricsClass = Metrics::class.java
+        listOf("counters", "timers", "longGauges", "intGauges").forEach { fieldName ->
+            val field = metricsClass.getDeclaredField(fieldName)
+            field.isAccessible = true
+            val map = field.get(Metrics) as? MutableMap<*, *>
+            map?.clear()
+        }
+    }
+
+    private companion object {
+        private const val USER_ID = 555L
+        private const val COMPONENT_VALUE = "payments"
+        private const val RESULT_OK = "ok"
+        private const val RESULT_FAIL = "fail"
+        private const val DEFAULT_ERROR_MESSAGE = "Payment rejected: invalid parameters."
+    }
+}


### PR DESCRIPTION
## Summary
- add a pre-checkout handler that validates invoice payloads and responds via answerPreCheckoutQuery
- route Telegram updates for pre_checkout_query through the new handler and expose metrics
- cover the handler with unit tests for success and failure paths

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d72ada0264832181598b8cb5dbbec7