### PR TITLE
Handle successful payment webhook

### DIFF
--- a/src/main/kotlin/com/example/app/observability/Metrics.kt
+++ b/src/main/kotlin/com/example/app/observability/Metrics.kt
@@ -40,6 +40,10 @@ object MetricsNames {
     const val ADMIN_FAIL_TOTAL = "tg_admin_webhook_fail_total"
 
     const val PRE_CHECKOUT_TOTAL = "tg_pre_checkout_total"
+
+    const val PAY_SUCCESS_TOTAL = "pay_success_total"
+    const val PAY_SUCCESS_IDEMPOTENT_TOTAL = "pay_success_idempotent_total"
+    const val PAY_SUCCESS_FAIL_TOTAL = "pay_success_fail_total"
 }
 
 object MetricsTags {

--- a/src/main/kotlin/com/example/app/payments/AwardPlan.kt
+++ b/src/main/kotlin/com/example/app/payments/AwardPlan.kt
@@ -1,0 +1,17 @@
+package com.example.app.payments
+
+import com.example.giftsbot.rng.RngDrawRecord
+import com.example.giftsbot.rng.RngReceipt
+
+data class AwardPlan(
+    val telegramPaymentChargeId: String,
+    val providerPaymentChargeId: String?,
+    val totalAmount: Long,
+    val currency: String,
+    val userId: Long,
+    val caseId: String,
+    val nonce: String,
+    val resultItemId: String?,
+    val rngRecord: RngDrawRecord,
+    val rngReceipt: RngReceipt,
+)

--- a/src/main/kotlin/com/example/app/payments/SuccessfulPaymentHandler.kt
+++ b/src/main/kotlin/com/example/app/payments/SuccessfulPaymentHandler.kt
@@ -1,0 +1,286 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.app.payments.dto.PaymentPayload
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.rng.RngService
+import com.example.giftsbot.rng.buildUserReceiptText
+import com.example.giftsbot.telegram.MessageDto
+import com.example.giftsbot.telegram.SuccessfulPaymentDto
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+class SuccessfulPaymentHandler(
+    private val telegramApiClient: TelegramApiClient,
+    private val rngService: RngService,
+    private val casesRepository: CasesRepository,
+    private val awardService: AwardService,
+    private val paymentsConfig: PaymentsConfig,
+    meterRegistry: MeterRegistry,
+) {
+    private val metrics = SuccessfulPaymentMetrics(meterRegistry)
+    private val processedPayments = ConcurrentHashMap<String, ProcessedPaymentState>()
+
+    suspend fun handle(updateId: Long, message: MessageDto) {
+        val payment = message.successful_payment
+        if (payment == null) {
+            metrics.markFailure()
+            logger.warn(
+                "successful payment missing: updateId={} messageId={} chatId={}",
+                updateId,
+                message.message_id,
+                message.chat.id,
+            )
+            return
+        }
+
+        val chargeId = payment.telegram_payment_charge_id.trim()
+        if (chargeId.isEmpty()) {
+            metrics.markFailure()
+            logger.warn(
+                "successful payment rejected: updateId={} reason={} messageId={} chatId={}",
+                updateId,
+                "charge_id_blank",
+                message.message_id,
+                message.chat.id,
+            )
+            return
+        }
+
+        val previousState = processedPayments.putIfAbsent(chargeId, ProcessedPaymentState.InProgress)
+        if (previousState != null) {
+            metrics.markIdempotent()
+            logDuplicate(updateId, chargeId, previousState)
+            return
+        }
+
+        val validation = validate(message, payment)
+        if (validation is ValidationResult.Failure) {
+            processedPayments.remove(chargeId, ProcessedPaymentState.InProgress)
+            metrics.markFailure()
+            logValidationFailure(updateId, chargeId, message, validation)
+            return
+        }
+
+        val payload = (validation as ValidationResult.Success).payload
+        val providerChargeId = payment.provider_payment_charge_id?.trim()?.takeUnless { it.isEmpty() }
+
+        try {
+            val drawResult = rngService.draw(payload.caseId, payload.userId, payload.nonce)
+            val plan =
+                AwardPlan(
+                    telegramPaymentChargeId = chargeId,
+                    providerPaymentChargeId = providerChargeId,
+                    totalAmount = payment.total_amount,
+                    currency = payment.currency,
+                    userId = payload.userId,
+                    caseId = payload.caseId,
+                    nonce = payload.nonce,
+                    resultItemId = drawResult.record.resultItemId,
+                    rngRecord = drawResult.record,
+                    rngReceipt = drawResult.receipt,
+                )
+
+            awardService.schedule(plan)
+            processedPayments[chargeId] = ProcessedPaymentState.Completed(plan)
+            metrics.markSuccess()
+            logger.info(
+                "successful payment processed: updateId={} chargeId={} userId={} caseId={} amount={} resultItemId={}",
+                updateId,
+                chargeId,
+                plan.userId,
+                plan.caseId,
+                plan.totalAmount,
+                plan.resultItemId ?: "-",
+            )
+            sendReceiptIfEnabled(updateId, message, plan)
+        } catch (cause: Throwable) {
+            processedPayments.remove(chargeId, ProcessedPaymentState.InProgress)
+            metrics.markFailure()
+            logger.error(
+                "successful payment failed: updateId={} chargeId={} userId={} caseId={}",
+                updateId,
+                chargeId,
+                payload.userId,
+                payload.caseId,
+                cause,
+            )
+            throw cause
+        }
+    }
+
+    private fun validate(
+        message: MessageDto,
+        payment: SuccessfulPaymentDto,
+    ): ValidationResult {
+        val payloadResult = runCatching { PaymentPayload.decode(payment.invoice_payload) }
+        val payload = payloadResult.getOrElse { cause ->
+            return ValidationResult.Failure("invalid_payload", cause)
+        }
+
+        val chatId = message.chat.id
+        val fromId = message.from?.id
+        if (payload.userId != chatId) {
+            return ValidationResult.Failure(
+                "user_mismatch expected=${payload.userId} actual=$chatId",
+            )
+        }
+        if (fromId != null && fromId != payload.userId) {
+            return ValidationResult.Failure(
+                "sender_mismatch expected=${payload.userId} actual=$fromId",
+            )
+        }
+        if (payload.nonce.isBlank()) {
+            return ValidationResult.Failure("nonce_blank")
+        }
+        if (payload.caseId.isBlank()) {
+            return ValidationResult.Failure("case_id_blank")
+        }
+
+        if (!payment.currency.equals(paymentsConfig.currency, ignoreCase = false)) {
+            return ValidationResult.Failure(
+                "invalid_currency expected=${paymentsConfig.currency} actual=${payment.currency}",
+            )
+        }
+
+        val case = casesRepository.get(payload.caseId)
+            ?: return ValidationResult.Failure("case_not_found caseId=${payload.caseId}")
+
+        if (payment.total_amount != case.priceStars) {
+            return ValidationResult.Failure(
+                "invalid_amount expected=${case.priceStars} actual=${payment.total_amount}",
+            )
+        }
+
+        return ValidationResult.Success(payload = payload)
+    }
+
+    private suspend fun sendReceiptIfEnabled(
+        updateId: Long,
+        message: MessageDto,
+        plan: AwardPlan,
+    ) {
+        if (!paymentsConfig.receiptEnabled) {
+            return
+        }
+        val text = buildUserReceiptText(plan.rngReceipt, plan.resultItemId)
+        runCatching {
+            telegramApiClient.sendMessage(
+                chatId = message.chat.id,
+                text = text,
+                disableNotification = true,
+                replyToMessageId = message.message_id,
+            )
+        }.onSuccess {
+            logger.info(
+                "successful payment receipt sent: updateId={} chargeId={} chatId={} messageId={} textLength={}",
+                updateId,
+                plan.telegramPaymentChargeId,
+                message.chat.id,
+                message.message_id,
+                text.length,
+            )
+        }.onFailure { cause ->
+            logger.warn(
+                "successful payment receipt failed: updateId={} chargeId={} chatId={} messageId={} reason={}",
+                updateId,
+                plan.telegramPaymentChargeId,
+                message.chat.id,
+                message.message_id,
+                cause.message,
+                cause,
+            )
+        }
+    }
+
+    private fun logDuplicate(
+        updateId: Long,
+        chargeId: String,
+        state: ProcessedPaymentState,
+    ) {
+        val plan = (state as? ProcessedPaymentState.Completed)?.plan
+        logger.info(
+            "successful payment duplicate: updateId={} chargeId={} userId={} caseId={}",
+            updateId,
+            chargeId,
+            plan?.userId,
+            plan?.caseId,
+        )
+    }
+
+    private fun logValidationFailure(
+        updateId: Long,
+        chargeId: String,
+        message: MessageDto,
+        failure: ValidationResult.Failure,
+    ) {
+        val cause = failure.cause
+        if (cause != null) {
+            logger.warn(
+                "successful payment rejected: updateId={} chargeId={} messageId={} chatId={} reason={}",
+                updateId,
+                chargeId,
+                message.message_id,
+                message.chat.id,
+                failure.reason,
+                cause,
+            )
+        } else {
+            logger.warn(
+                "successful payment rejected: updateId={} chargeId={} messageId={} chatId={} reason={}",
+                updateId,
+                chargeId,
+                message.message_id,
+                message.chat.id,
+                failure.reason,
+            )
+        }
+    }
+
+    private class SuccessfulPaymentMetrics(registry: MeterRegistry) {
+        private val componentTag = MetricsTags.COMPONENT to COMPONENT_VALUE
+        private val successCounter =
+            Metrics.counter(registry, MetricsNames.PAY_SUCCESS_TOTAL, componentTag)
+        private val idempotentCounter =
+            Metrics.counter(registry, MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL, componentTag)
+        private val failureCounter =
+            Metrics.counter(registry, MetricsNames.PAY_SUCCESS_FAIL_TOTAL, componentTag)
+
+        fun markSuccess() {
+            successCounter.increment()
+        }
+
+        fun markIdempotent() {
+            idempotentCounter.increment()
+        }
+
+        fun markFailure() {
+            failureCounter.increment()
+        }
+    }
+
+    private sealed interface ValidationResult {
+        data class Success(val payload: PaymentPayload) : ValidationResult
+
+        data class Failure(val reason: String, val cause: Throwable? = null) : ValidationResult
+    }
+
+    private sealed interface ProcessedPaymentState {
+        data class Completed(val plan: AwardPlan) : ProcessedPaymentState
+
+        object InProgress : ProcessedPaymentState
+    }
+
+    companion object {
+        private const val COMPONENT_VALUE = "payments"
+        private val logger = LoggerFactory.getLogger(SuccessfulPaymentHandler::class.java)
+    }
+}
+
+interface AwardService {
+    suspend fun schedule(plan: AwardPlan)
+}

--- a/src/main/kotlin/com/example/app/rng/RngBootstrap.kt
+++ b/src/main/kotlin/com/example/app/rng/RngBootstrap.kt
@@ -2,14 +2,17 @@ package com.example.app.rng
 
 import com.example.giftsbot.economy.CasesRepository
 import com.example.giftsbot.rng.RngConfig
+import com.example.giftsbot.rng.RngService
 import com.example.giftsbot.rng.SystemEnvReader
 import io.ktor.server.application.Application
 import io.ktor.server.routing.routing
+import io.ktor.util.AttributeKey
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import java.time.Clock
 
 private val logger = LoggerFactory.getLogger("RngBootstrap")
+private val rngServiceKey = AttributeKey<RngService>("rngService")
 
 fun Application.installRngIntegration(meterRegistry: MeterRegistry) {
     val env = SystemEnvReader
@@ -33,6 +36,8 @@ fun Application.installRngIntegration(meterRegistry: MeterRegistry) {
 
     val adminToken = env.get("ADMIN_TOKEN")
 
+    attributes.put(rngServiceKey, rngService)
+
     routing {
         rngRoutes(
             service = rngService,
@@ -41,3 +46,5 @@ fun Application.installRngIntegration(meterRegistry: MeterRegistry) {
         )
     }
 }
+
+fun Application.getRngService(): RngService = attributes[rngServiceKey]

--- a/src/main/kotlin/com/example/app/telegram/IncomingUpdate.kt
+++ b/src/main/kotlin/com/example/app/telegram/IncomingUpdate.kt
@@ -3,6 +3,7 @@ package com.example.app.telegram
 import com.example.app.telegram.dto.UpdateDto
 import com.example.giftsbot.telegram.MessageDto as MessageDto
 import com.example.giftsbot.telegram.PreCheckoutQueryDto as PreCheckoutQueryDto
+import com.example.giftsbot.telegram.SuccessfulPaymentDto as SuccessfulPaymentDto
 
 sealed interface IncomingUpdate {
     val updateId: Long
@@ -17,6 +18,12 @@ sealed interface IncomingUpdate {
         val query: PreCheckoutQueryDto,
     ) : IncomingUpdate
 
+    data class SuccessfulPaymentUpdate(
+        override val updateId: Long,
+        val message: MessageDto,
+        val payment: SuccessfulPaymentDto,
+    ) : IncomingUpdate
+
     data class RawUpdate(
         override val updateId: Long,
         val dto: UpdateDto,
@@ -26,6 +33,8 @@ sealed interface IncomingUpdate {
 /** Простая адаптация из UpdateDto в IncomingUpdate. Новые типы дополним позже. */
 fun UpdateDto.toIncoming(): IncomingUpdate =
     when {
+        message?.successful_payment != null ->
+            IncomingUpdate.SuccessfulPaymentUpdate(update_id, message, message.successful_payment)
         pre_checkout_query != null -> IncomingUpdate.PreCheckoutQueryUpdate(update_id, pre_checkout_query)
         message != null -> IncomingUpdate.MessageUpdate(update_id, message)
         else -> IncomingUpdate.RawUpdate(update_id, this)

--- a/src/main/kotlin/com/example/app/telegram/WebhookUpdateRouter.kt
+++ b/src/main/kotlin/com/example/app/telegram/WebhookUpdateRouter.kt
@@ -1,13 +1,16 @@
 package com.example.app.telegram
 
 import com.example.app.payments.PreCheckoutHandler
+import com.example.app.payments.SuccessfulPaymentHandler
 import org.slf4j.LoggerFactory
 
 class WebhookUpdateRouter(
     private val preCheckoutHandler: PreCheckoutHandler,
+    private val successfulPaymentHandler: SuccessfulPaymentHandler,
 ) {
     suspend fun route(incoming: IncomingUpdate) {
         when (incoming) {
+            is IncomingUpdate.SuccessfulPaymentUpdate -> handleSuccessfulPayment(incoming)
             is IncomingUpdate.PreCheckoutQueryUpdate -> handlePreCheckout(incoming)
             else -> logger.debug(
                 "no handler for updateId={} type={}",
@@ -15,6 +18,10 @@ class WebhookUpdateRouter(
                 incoming::class.simpleName,
             )
         }
+    }
+
+    private suspend fun handleSuccessfulPayment(incoming: IncomingUpdate.SuccessfulPaymentUpdate) {
+        successfulPaymentHandler.handle(incoming.updateId, incoming.message)
     }
 
     private suspend fun handlePreCheckout(incoming: IncomingUpdate.PreCheckoutQueryUpdate) {

--- a/src/main/kotlin/com/example/giftsbot/telegram/TelegramApiClient.kt
+++ b/src/main/kotlin/com/example/giftsbot/telegram/TelegramApiClient.kt
@@ -169,6 +169,31 @@ class TelegramApiClient(
         throw TelegramApiException("Telegram API answerPreCheckoutQuery returned false result")
     }
 
+    suspend fun sendMessage(
+        chatId: Long,
+        text: String,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+    ): MessageDto {
+        logger.debug(
+            "sendMessage request chatId={} disableNotification={} replyToMessageId={} textLength={}",
+            chatId,
+            disableNotification,
+            replyToMessageId,
+            text.length,
+        )
+        return execute(
+            methodName = "sendMessage",
+            body =
+                SendMessageRequest(
+                    chatId = chatId,
+                    text = text,
+                    disableNotification = disableNotification,
+                    replyToMessageId = replyToMessageId,
+                ),
+        )
+    }
+
     suspend fun getUpdates(
         offset: Long?,
         timeoutSeconds: Int,
@@ -342,6 +367,17 @@ private data class AnswerPreCheckoutQueryRequest(
     val ok: Boolean,
     @SerialName("error_message")
     val errorMessage: String? = null,
+)
+
+@Serializable
+private data class SendMessageRequest(
+    @SerialName("chat_id")
+    val chatId: Long,
+    val text: String,
+    @SerialName("disable_notification")
+    val disableNotification: Boolean? = null,
+    @SerialName("reply_to_message_id")
+    val replyToMessageId: Long? = null,
 )
 
 @Serializable

--- a/src/test/kotlin/com/example/app/payments/SuccessfulPaymentHandlerTest.kt
+++ b/src/test/kotlin/com/example/app/payments/SuccessfulPaymentHandlerTest.kt
@@ -1,0 +1,303 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.app.payments.dto.PaymentPayload
+import com.example.giftsbot.economy.CaseConfig
+import com.example.giftsbot.economy.CaseSlotType
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.economy.PrizeItemConfig
+import com.example.giftsbot.rng.RngDrawRecord
+import com.example.giftsbot.rng.RngDrawResult
+import com.example.giftsbot.rng.RngReceipt
+import com.example.giftsbot.rng.RngService
+import com.example.giftsbot.telegram.ChatDto
+import com.example.giftsbot.telegram.MessageDto
+import com.example.giftsbot.telegram.SuccessfulPaymentDto
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SuccessfulPaymentHandlerTest {
+    @MockK
+    private lateinit var telegramApiClient: TelegramApiClient
+
+    @MockK
+    private lateinit var rngService: RngService
+
+    @MockK
+    private lateinit var casesRepository: CasesRepository
+
+    @MockK
+    private lateinit var awardService: AwardService
+
+    private lateinit var meterRegistry: MeterRegistry
+
+    private lateinit var handler: SuccessfulPaymentHandler
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+        meterRegistry = SimpleMeterRegistry()
+        val paymentsConfig = PaymentsConfig(currency = STARS_CURRENCY_CODE, titlePrefix = null, receiptEnabled = true, businessConnectionId = null)
+        handler = SuccessfulPaymentHandler(
+            telegramApiClient = telegramApiClient,
+            rngService = rngService,
+            casesRepository = casesRepository,
+            awardService = awardService,
+            paymentsConfig = paymentsConfig,
+            meterRegistry = meterRegistry,
+        )
+    }
+
+    @Test
+    fun `handle successful payment builds plan and sends receipt`() = runTest {
+        val case = CaseConfig(
+            id = "case-1",
+            title = "Case 1",
+            priceStars = 100,
+            rtpExtMin = 0.4,
+            rtpExtMax = 0.5,
+            jackpotAlpha = 0.02,
+            items = listOf(PrizeItemConfig(id = "item-1", type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
+        )
+        val planSlot = slot<AwardPlan>()
+        coEvery { awardService.schedule(capture(planSlot)) } returns Unit
+        every { casesRepository.get(case.id) } returns case
+        val payload = PaymentPayload(caseId = case.id, userId = 777, nonce = "nonce", ts = 1L)
+        val drawRecord =
+            RngDrawRecord(
+                caseId = case.id,
+                userId = payload.userId,
+                nonce = payload.nonce,
+                serverSeedHash = "hash",
+                rollHex = "abcdef",
+                ppm = 123,
+                resultItemId = "item-1",
+                createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+            )
+        val receipt =
+            RngReceipt(
+                date = LocalDate.parse("2024-01-01"),
+                serverSeedHash = "hash",
+                clientSeed = "client-seed",
+                rollHex = "abcdef",
+                ppm = 123,
+            )
+        every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
+        coEvery {
+            telegramApiClient.sendMessage(
+                chatId = payload.userId,
+                text = any(),
+                disableNotification = true,
+                replyToMessageId = any(),
+            )
+        } returns messageStub(chatId = payload.userId)
+
+        val message = successfulPaymentMessage(
+            chargeId = "charge-1",
+            payload = payload.encode(),
+            userId = payload.userId,
+            totalAmount = case.priceStars,
+            currency = STARS_CURRENCY_CODE,
+        )
+
+        val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
+        val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
+        val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
+        handler.handle(updateId = 1L, message = message)
+
+        val capturedPlan = planSlot.captured
+        assertNotNull(capturedPlan)
+        assertEquals("charge-1", capturedPlan.telegramPaymentChargeId)
+        assertEquals(case.id, capturedPlan.caseId)
+        assertEquals(payload.userId, capturedPlan.userId)
+        assertEquals(payload.nonce, capturedPlan.nonce)
+        assertEquals(case.priceStars, capturedPlan.totalAmount)
+        assertEquals(STARS_CURRENCY_CODE, capturedPlan.currency)
+        assertEquals(drawRecord, capturedPlan.rngRecord)
+        assertEquals(receipt, capturedPlan.rngReceipt)
+        assertEquals("item-1", capturedPlan.resultItemId)
+
+        assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
+        assertEquals(idempotentBefore, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
+        assertEquals(failBefore, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
+
+        coVerify(exactly = 1) { awardService.schedule(any()) }
+        coVerify(exactly = 1) { telegramApiClient.sendMessage(payload.userId, any(), true, message.message_id) }
+    }
+
+    @Test
+    fun `duplicate payment is idempotent`() = runTest {
+        val case = CaseConfig(
+            id = "case-2",
+            title = "Case 2",
+            priceStars = 200,
+            rtpExtMin = 0.4,
+            rtpExtMax = 0.5,
+            jackpotAlpha = 0.02,
+            items = listOf(PrizeItemConfig(id = "item-2", type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
+        )
+        coEvery { awardService.schedule(any()) } returns Unit
+        every { casesRepository.get(case.id) } returns case
+        val payload = PaymentPayload(caseId = case.id, userId = 900, nonce = "nonce", ts = 1L)
+        val drawRecord =
+            RngDrawRecord(
+                caseId = case.id,
+                userId = payload.userId,
+                nonce = payload.nonce,
+                serverSeedHash = "hash",
+                rollHex = "abcdef",
+                ppm = 456,
+                resultItemId = "item-2",
+                createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+            )
+        val receipt =
+            RngReceipt(
+                date = LocalDate.parse("2024-01-02"),
+                serverSeedHash = "hash",
+                clientSeed = "seed",
+                rollHex = "abcdef",
+                ppm = 456,
+            )
+        every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
+        coEvery {
+            telegramApiClient.sendMessage(payload.userId, any(), true, any())
+        } returns messageStub(chatId = payload.userId)
+
+        val message = successfulPaymentMessage(
+            chargeId = "charge-dup",
+            payload = payload.encode(),
+            userId = payload.userId,
+            totalAmount = case.priceStars,
+            currency = STARS_CURRENCY_CODE,
+        )
+
+        val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
+        val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
+        val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
+        handler.handle(updateId = 100L, message = message)
+        handler.handle(updateId = 101L, message = message)
+
+        assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
+        assertEquals(idempotentBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
+        assertEquals(failBefore, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
+
+        coVerify(exactly = 1) { awardService.schedule(any()) }
+        coVerify(exactly = 1) { telegramApiClient.sendMessage(payload.userId, any(), true, message.message_id) }
+    }
+
+    @Test
+    fun `validation failure is retriable`() = runTest {
+        val case = CaseConfig(
+            id = "case-3",
+            title = "Case 3",
+            priceStars = 300,
+            rtpExtMin = 0.4,
+            rtpExtMax = 0.5,
+            jackpotAlpha = 0.02,
+            items = listOf(PrizeItemConfig(id = "item-3", type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
+        )
+        every { casesRepository.get(case.id) } returns case
+        coEvery { awardService.schedule(any()) } returns Unit
+        val payload = PaymentPayload(caseId = case.id, userId = 42, nonce = "nonce", ts = 1L)
+        val drawRecord =
+            RngDrawRecord(
+                caseId = case.id,
+                userId = payload.userId,
+                nonce = payload.nonce,
+                serverSeedHash = "hash",
+                rollHex = "abc123",
+                ppm = 789,
+                resultItemId = null,
+                createdAt = Instant.parse("2024-01-03T00:00:00Z"),
+            )
+        val receipt =
+            RngReceipt(
+                date = LocalDate.parse("2024-01-03"),
+                serverSeedHash = "hash",
+                clientSeed = "seed",
+                rollHex = "abc123",
+                ppm = 789,
+            )
+        every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
+        coEvery { telegramApiClient.sendMessage(payload.userId, any(), true, any()) } returns messageStub(chatId = payload.userId)
+
+        val invalidMessage = successfulPaymentMessage(
+            chargeId = "charge-retry",
+            payload = payload.encode(),
+            userId = payload.userId,
+            totalAmount = case.priceStars,
+            currency = "USD",
+        )
+        val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
+        val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
+        val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
+        handler.handle(updateId = 200L, message = invalidMessage)
+
+        assertEquals(successBefore, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
+        assertEquals(idempotentBefore, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
+        assertEquals(failBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
+        coVerify(exactly = 0) { awardService.schedule(any()) }
+
+        val validMessage = successfulPaymentMessage(
+            chargeId = "charge-retry",
+            payload = payload.encode(),
+            userId = payload.userId,
+            totalAmount = case.priceStars,
+            currency = STARS_CURRENCY_CODE,
+        )
+        handler.handle(updateId = 201L, message = validMessage)
+
+        assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
+        assertEquals(idempotentBefore, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
+        assertEquals(failBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
+        coVerify(exactly = 1) { awardService.schedule(any()) }
+    }
+
+    private fun metricCount(name: String): Double =
+        Metrics.counter(meterRegistry, name, MetricsTags.COMPONENT to "payments").count()
+
+    private fun successfulPaymentMessage(
+        chargeId: String,
+        payload: String,
+        userId: Long,
+        totalAmount: Long,
+        currency: String,
+    ): MessageDto =
+        MessageDto(
+            message_id = 1,
+            date = 0,
+            chat = ChatDto(id = userId, type = "private"),
+            successful_payment =
+                SuccessfulPaymentDto(
+                    currency = currency,
+                    total_amount = totalAmount,
+                    invoice_payload = payload,
+                    telegram_payment_charge_id = chargeId,
+                    provider_payment_charge_id = "provider",
+                ),
+        )
+
+    private fun messageStub(chatId: Long): MessageDto =
+        MessageDto(
+            message_id = 10,
+            date = 0,
+            chat = ChatDto(id = chatId, type = "private"),
+        )
+
+}


### PR DESCRIPTION
## Summary
- implement a SuccessfulPaymentHandler that validates payment updates, draws RNG results, builds an AwardPlan, records metrics, and optionally sends receipts
- extend the Telegram integration to route successful_payment updates, expose the RNG service, and add sendMessage support alongside new payment metrics
- cover the new handler behaviour with unit tests

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d73c6b0d5083219a63596be841bbc0