### PR TITLE
Add refund service for Telegram star payments

### DIFF
--- a/src/main/kotlin/com/example/app/observability/Metrics.kt
+++ b/src/main/kotlin/com/example/app/observability/Metrics.kt
@@ -49,6 +49,9 @@ object MetricsNames {
     const val AWARD_PREMIUM_TOTAL = "award_premium_total"
     const val AWARD_INTERNAL_TOTAL = "award_internal_total"
     const val AWARD_FAIL_TOTAL = "award_fail_total"
+
+    const val REFUND_TOTAL = "refund_total"
+    const val REFUND_FAIL_TOTAL = "refund_fail_total"
 }
 
 object MetricsTags {

--- a/src/main/kotlin/com/example/app/payments/PaymentSupport.kt
+++ b/src/main/kotlin/com/example/app/payments/PaymentSupport.kt
@@ -1,0 +1,6 @@
+package com.example.app.payments
+
+data class PaymentSupport(
+    val config: PaymentsConfig,
+    val refundService: RefundService,
+)

--- a/src/main/kotlin/com/example/app/payments/RefundService.kt
+++ b/src/main/kotlin/com/example/app/payments/RefundService.kt
@@ -1,0 +1,278 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+private const val REFUND_COMPONENT = "payments"
+private val COMPONENT_TAG = MetricsTags.COMPONENT to REFUND_COMPONENT
+private val REFUND_SLA = Duration.ofSeconds(2)
+
+class RefundService(
+    private val telegramApiClient: TelegramApiClient,
+    meterRegistry: MeterRegistry,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    private val logger = LoggerFactory.getLogger(RefundService::class.java)
+    private val journal = ConcurrentHashMap<String, RefundJournalEntry>()
+    private val refundCounter =
+        Metrics.counter(meterRegistry, MetricsNames.REFUND_TOTAL, COMPONENT_TAG)
+    private val refundFailCounter =
+        Metrics.counter(meterRegistry, MetricsNames.REFUND_FAIL_TOTAL, COMPONENT_TAG)
+
+    suspend fun refundStarPayment(
+        userId: Long,
+        telegramPaymentChargeId: String,
+        reason: RefundReason,
+    ) {
+        val normalizedChargeId = telegramPaymentChargeId.trim()
+        require(userId > 0) { "userId must be positive" }
+        require(normalizedChargeId.isNotEmpty()) { "telegramPaymentChargeId must not be blank" }
+
+        val startDecision = beginAttempt(normalizedChargeId, reason)
+        when (startDecision) {
+            is BeginResult.Skip -> {
+                logDuplicate(userId, normalizedChargeId, startDecision.previous, reason)
+                return
+            }
+            is BeginResult.Start -> {
+                executeRefund(userId, normalizedChargeId, reason, startDecision.attempt)
+            }
+        }
+    }
+
+    private fun beginAttempt(
+        chargeId: String,
+        reason: RefundReason,
+    ): BeginResult {
+        val startedAt = clock.instant()
+        var previous: RefundJournalEntry? = null
+        val entry =
+            journal.compute(chargeId) { _, existing ->
+                previous = existing
+                when (existing) {
+                    null -> RefundJournalEntry.InProgress(reason, startedAt, attempt = 1)
+                    is RefundJournalEntry.Failed ->
+                        RefundJournalEntry.InProgress(reason, startedAt, attempt = existing.attempt + 1)
+                    else -> existing
+                }
+            }
+        return if (entry is RefundJournalEntry.InProgress) {
+            BeginResult.Start(entry)
+        } else {
+            BeginResult.Skip(previous ?: entry)
+        }
+    }
+
+    private suspend fun executeRefund(
+        userId: Long,
+        chargeId: String,
+        reason: RefundReason,
+        attempt: Int,
+    ) {
+        val startedAt = clock.instant()
+        runCatching { telegramApiClient.refundStarPayment(userId, chargeId) }
+            .onSuccess {
+                val duration = Duration.between(startedAt, clock.instant())
+                finishSuccess(chargeId, reason, attempt, duration)
+                logSuccess(userId, chargeId, reason, attempt, duration)
+            }
+            .onFailure { cause ->
+                finishFailure(chargeId, reason, attempt, cause)
+                logFailure(userId, chargeId, reason, attempt, cause)
+                throw cause
+            }
+    }
+
+    private fun finishSuccess(
+        chargeId: String,
+        reason: RefundReason,
+        attempt: Int,
+        duration: Duration,
+    ) {
+        refundCounter.increment()
+        journal[chargeId] = RefundJournalEntry.Succeeded(reason, attempt, duration, clock.instant())
+    }
+
+    private fun finishFailure(
+        chargeId: String,
+        reason: RefundReason,
+        attempt: Int,
+        cause: Throwable,
+    ) {
+        refundFailCounter.increment()
+        journal[chargeId] = RefundJournalEntry.Failed(reason, attempt, cause.message)
+    }
+
+    private fun logDuplicate(
+        userId: Long,
+        chargeId: String,
+        existing: RefundJournalEntry?,
+        newReason: RefundReason,
+    ) {
+        val state = existing?.status() ?: "none"
+        if (newReason.detail != null) {
+            logger.info(
+                "refund skipped: userId={} chargeId={} reason={} state={} detail={}",
+                userId,
+                chargeId,
+                newReason.code,
+                state,
+                newReason.detail,
+            )
+        } else {
+            logger.info(
+                "refund skipped: userId={} chargeId={} reason={} state={}",
+                userId,
+                chargeId,
+                newReason.code,
+                state,
+            )
+        }
+    }
+
+    private fun logSuccess(
+        userId: Long,
+        chargeId: String,
+        reason: RefundReason,
+        attempt: Int,
+        duration: Duration,
+    ) {
+        val durationMs = duration.toMillis()
+        if (duration > REFUND_SLA) {
+            if (reason.detail != null) {
+                logger.warn(
+                    "refund slow: userId={} chargeId={} reason={} attempt={} durationMs={} detail={}",
+                    userId,
+                    chargeId,
+                    reason.code,
+                    attempt,
+                    durationMs,
+                    reason.detail,
+                )
+            } else {
+                logger.warn(
+                    "refund slow: userId={} chargeId={} reason={} attempt={} durationMs={}",
+                    userId,
+                    chargeId,
+                    reason.code,
+                    attempt,
+                    durationMs,
+                )
+            }
+            return
+        }
+
+        if (reason.detail != null) {
+            logger.info(
+                "refund completed: userId={} chargeId={} reason={} attempt={} durationMs={} detail={}",
+                userId,
+                chargeId,
+                reason.code,
+                attempt,
+                durationMs,
+                reason.detail,
+            )
+        } else {
+            logger.info(
+                "refund completed: userId={} chargeId={} reason={} attempt={} durationMs={}",
+                userId,
+                chargeId,
+                reason.code,
+                attempt,
+                durationMs,
+            )
+        }
+    }
+
+    private fun logFailure(
+        userId: Long,
+        chargeId: String,
+        reason: RefundReason,
+        attempt: Int,
+        cause: Throwable,
+    ) {
+        if (reason.detail != null) {
+            logger.error(
+                "refund failed: userId={} chargeId={} reason={} attempt={} detail={}",
+                userId,
+                chargeId,
+                reason.code,
+                attempt,
+                reason.detail,
+                cause,
+            )
+        } else {
+            logger.error(
+                "refund failed: userId={} chargeId={} reason={} attempt={}",
+                userId,
+                chargeId,
+                reason.code,
+                attempt,
+                cause,
+            )
+        }
+    }
+
+    private sealed interface BeginResult {
+        data class Start(val entry: RefundJournalEntry.InProgress) : BeginResult
+
+        data class Skip(val previous: RefundJournalEntry?) : BeginResult
+    }
+
+    private sealed interface RefundJournalEntry {
+        val reason: RefundReason
+        val attempt: Int
+
+        data class InProgress(
+            override val reason: RefundReason,
+            val startedAt: Instant,
+            override val attempt: Int,
+        ) : RefundJournalEntry
+
+        data class Succeeded(
+            override val reason: RefundReason,
+            override val attempt: Int,
+            val duration: Duration,
+            val completedAt: Instant,
+        ) : RefundJournalEntry
+
+        data class Failed(
+            override val reason: RefundReason,
+            override val attempt: Int,
+            val lastError: String?,
+        ) : RefundJournalEntry
+    }
+
+    private fun RefundJournalEntry?.status(): String =
+        when (this) {
+            null -> "none"
+            is RefundJournalEntry.InProgress -> "in_progress"
+            is RefundJournalEntry.Succeeded -> "succeeded"
+            is RefundJournalEntry.Failed -> "failed"
+        }
+}
+
+sealed interface RefundReason {
+    val code: String
+    val detail: String?
+
+    data class Validation(override val detail: String) : RefundReason {
+        override val code: String = "validation_failure"
+    }
+
+    data class Draw(override val detail: String) : RefundReason {
+        override val code: String = "draw_failure"
+    }
+
+    data class Award(override val detail: String) : RefundReason {
+        override val code: String = "award_failure"
+    }
+}

--- a/src/main/kotlin/com/example/app/payments/SuccessfulPaymentHandler.kt
+++ b/src/main/kotlin/com/example/app/payments/SuccessfulPaymentHandler.kt
@@ -4,6 +4,8 @@ import com.example.app.observability.Metrics
 import com.example.app.observability.MetricsNames
 import com.example.app.observability.MetricsTags
 import com.example.app.payments.dto.PaymentPayload
+import com.example.app.payments.PaymentSupport
+import com.example.app.payments.RefundReason
 import com.example.giftsbot.economy.CasesRepository
 import com.example.giftsbot.rng.RngService
 import com.example.giftsbot.rng.buildUserReceiptText
@@ -11,6 +13,7 @@ import com.example.giftsbot.telegram.MessageDto
 import com.example.giftsbot.telegram.SuccessfulPaymentDto
 import com.example.giftsbot.telegram.TelegramApiClient
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CancellationException
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
@@ -19,9 +22,11 @@ class SuccessfulPaymentHandler(
     private val rngService: RngService,
     private val casesRepository: CasesRepository,
     private val awardService: AwardService,
-    private val paymentsConfig: PaymentsConfig,
+    paymentSupport: PaymentSupport,
     meterRegistry: MeterRegistry,
 ) {
+    private val refundService = paymentSupport.refundService
+    private val paymentsConfig = paymentSupport.config
     private val metrics = SuccessfulPaymentMetrics(meterRegistry)
     private val processedPayments = ConcurrentHashMap<String, ProcessedPaymentState>()
 
@@ -60,7 +65,13 @@ class SuccessfulPaymentHandler(
 
         val validation = validate(message, payment)
         if (validation is ValidationResult.Failure) {
-            processedPayments.remove(chargeId, ProcessedPaymentState.InProgress)
+            val refunded = refundAfterValidation(chargeId, validation)
+            processedPayments[chargeId] =
+                if (refunded) {
+                    ProcessedPaymentState.Refunded(RefundReason.Validation(validation.reason))
+                } else {
+                    ProcessedPaymentState.Failed(validation.reason)
+                }
             metrics.markFailure()
             logValidationFailure(updateId, chargeId, message, validation)
             return
@@ -69,9 +80,11 @@ class SuccessfulPaymentHandler(
         val payload = (validation as ValidationResult.Success).payload
         val providerChargeId = payment.provider_payment_charge_id?.trim()?.takeUnless { it.isEmpty() }
 
+        var plan: AwardPlan? = null
+        var awardAttempted = false
         try {
             val drawResult = rngService.draw(payload.caseId, payload.userId, payload.nonce)
-            val plan =
+            plan =
                 AwardPlan(
                     telegramPaymentChargeId = chargeId,
                     providerPaymentChargeId = providerChargeId,
@@ -85,6 +98,7 @@ class SuccessfulPaymentHandler(
                     rngReceipt = drawResult.receipt,
                 )
 
+            awardAttempted = true
             awardService.schedule(plan)
             processedPayments[chargeId] = ProcessedPaymentState.Completed(plan)
             metrics.markSuccess()
@@ -99,7 +113,25 @@ class SuccessfulPaymentHandler(
             )
             sendReceiptIfEnabled(updateId, message, plan)
         } catch (cause: Throwable) {
-            processedPayments.remove(chargeId, ProcessedPaymentState.InProgress)
+            if (cause is CancellationException) {
+                processedPayments.remove(chargeId, ProcessedPaymentState.InProgress)
+                throw cause
+            }
+            val detail = failureDetail(cause)
+            val refundReason = if (awardAttempted && plan != null) {
+                RefundReason.Award(detail)
+            } else {
+                RefundReason.Draw(detail)
+            }
+            val refundCurrency = plan?.currency ?: payment.currency
+            val refundUserId = plan?.userId ?: payload.userId
+            val refunded = attemptRefund(chargeId, refundUserId, refundCurrency, refundReason)
+            processedPayments[chargeId] =
+                if (refunded) {
+                    ProcessedPaymentState.Refunded(refundReason)
+                } else {
+                    ProcessedPaymentState.Failed(refundReason.detail)
+                }
             metrics.markFailure()
             logger.error(
                 "successful payment failed: updateId={} chargeId={} userId={} caseId={}",
@@ -119,45 +151,119 @@ class SuccessfulPaymentHandler(
     ): ValidationResult {
         val payloadResult = runCatching { PaymentPayload.decode(payment.invoice_payload) }
         val payload = payloadResult.getOrElse { cause ->
-            return ValidationResult.Failure("invalid_payload", cause)
+            val context = message.from?.id?.takeIf { it > 0 }?.let { RefundContext(userId = it, currency = payment.currency) }
+            return ValidationResult.Failure("invalid_payload", cause, context)
         }
+        val refundContext = RefundContext(userId = payload.userId, currency = payment.currency)
 
         val chatId = message.chat.id
         val fromId = message.from?.id
         if (payload.userId != chatId) {
             return ValidationResult.Failure(
                 "user_mismatch expected=${payload.userId} actual=$chatId",
+                refundContext = refundContext,
             )
         }
         if (fromId != null && fromId != payload.userId) {
             return ValidationResult.Failure(
                 "sender_mismatch expected=${payload.userId} actual=$fromId",
+                refundContext = refundContext,
             )
         }
         if (payload.nonce.isBlank()) {
-            return ValidationResult.Failure("nonce_blank")
+            return ValidationResult.Failure("nonce_blank", refundContext = refundContext)
         }
         if (payload.caseId.isBlank()) {
-            return ValidationResult.Failure("case_id_blank")
+            return ValidationResult.Failure("case_id_blank", refundContext = refundContext)
         }
 
         if (!payment.currency.equals(paymentsConfig.currency, ignoreCase = false)) {
             return ValidationResult.Failure(
                 "invalid_currency expected=${paymentsConfig.currency} actual=${payment.currency}",
+                refundContext = refundContext,
             )
         }
 
         val case = casesRepository.get(payload.caseId)
-            ?: return ValidationResult.Failure("case_not_found caseId=${payload.caseId}")
+            ?: return ValidationResult.Failure("case_not_found caseId=${payload.caseId}", refundContext = refundContext)
 
         if (payment.total_amount != case.priceStars) {
             return ValidationResult.Failure(
                 "invalid_amount expected=${case.priceStars} actual=${payment.total_amount}",
+                refundContext = refundContext,
             )
         }
 
         return ValidationResult.Success(payload = payload)
     }
+
+    private suspend fun refundAfterValidation(
+        chargeId: String,
+        failure: ValidationResult.Failure,
+    ): Boolean {
+        val context = failure.refundContext
+        if (context == null) {
+            logger.info(
+                "refund skipped after validation: chargeId={} reason={} cause=missing_context",
+                chargeId,
+                failure.reason,
+            )
+            return false
+        }
+        return attemptRefund(
+            chargeId = chargeId,
+            userId = context.userId,
+            currency = context.currency,
+            reason = RefundReason.Validation(failure.reason),
+        )
+    }
+
+    private suspend fun attemptRefund(
+        chargeId: String,
+        userId: Long,
+        currency: String,
+        reason: RefundReason,
+    ): Boolean {
+        if (!currency.equals(STARS_CURRENCY_CODE, ignoreCase = true)) {
+            logger.warn(
+                "refund skipped: chargeId={} userId={} reason={} currency={}",
+                chargeId,
+                userId,
+                reason.code,
+                currency,
+            )
+            return false
+        }
+        return runCatching {
+            refundService.refundStarPayment(
+                userId = userId,
+                telegramPaymentChargeId = chargeId,
+                reason = reason,
+            )
+        }.onFailure { cause ->
+            if (reason.detail != null) {
+                logger.error(
+                    "refund attempt failed: chargeId={} userId={} reason={} detail={}",
+                    chargeId,
+                    userId,
+                    reason.code,
+                    reason.detail,
+                    cause,
+                )
+            } else {
+                logger.error(
+                    "refund attempt failed: chargeId={} userId={} reason={}",
+                    chargeId,
+                    userId,
+                    reason.code,
+                    cause,
+                )
+            }
+        }.isSuccess
+    }
+
+    private fun failureDetail(cause: Throwable): String =
+        cause.message?.takeIf { it.isNotBlank() } ?: cause.javaClass.simpleName
 
     private suspend fun sendReceiptIfEnabled(
         updateId: Long,
@@ -202,14 +308,51 @@ class SuccessfulPaymentHandler(
         chargeId: String,
         state: ProcessedPaymentState,
     ) {
-        val plan = (state as? ProcessedPaymentState.Completed)?.plan
-        logger.info(
-            "successful payment duplicate: updateId={} chargeId={} userId={} caseId={}",
-            updateId,
-            chargeId,
-            plan?.userId,
-            plan?.caseId,
-        )
+        when (state) {
+            is ProcessedPaymentState.Completed -> {
+                val plan = state.plan
+                logger.info(
+                    "successful payment duplicate: updateId={} chargeId={} userId={} caseId={}",
+                    updateId,
+                    chargeId,
+                    plan.userId,
+                    plan.caseId,
+                )
+            }
+            is ProcessedPaymentState.Refunded -> {
+                if (state.reason.detail != null) {
+                    logger.info(
+                        "successful payment duplicate refunded: updateId={} chargeId={} reason={} detail={}",
+                        updateId,
+                        chargeId,
+                        state.reason.code,
+                        state.reason.detail,
+                    )
+                } else {
+                    logger.info(
+                        "successful payment duplicate refunded: updateId={} chargeId={} reason={}",
+                        updateId,
+                        chargeId,
+                        state.reason.code,
+                    )
+                }
+            }
+            is ProcessedPaymentState.Failed -> {
+                logger.info(
+                    "successful payment duplicate failed: updateId={} chargeId={} reason={}",
+                    updateId,
+                    chargeId,
+                    state.reason ?: "-",
+                )
+            }
+            ProcessedPaymentState.InProgress -> {
+                logger.info(
+                    "successful payment duplicate: updateId={} chargeId={} state=in_progress",
+                    updateId,
+                    chargeId,
+                )
+            }
+        }
     }
 
     private fun logValidationFailure(
@@ -266,11 +409,24 @@ class SuccessfulPaymentHandler(
     private sealed interface ValidationResult {
         data class Success(val payload: PaymentPayload) : ValidationResult
 
-        data class Failure(val reason: String, val cause: Throwable? = null) : ValidationResult
+        data class Failure(
+            val reason: String,
+            val cause: Throwable? = null,
+            val refundContext: RefundContext? = null,
+        ) : ValidationResult
     }
+
+    private data class RefundContext(
+        val userId: Long,
+        val currency: String,
+    )
 
     private sealed interface ProcessedPaymentState {
         data class Completed(val plan: AwardPlan) : ProcessedPaymentState
+
+        data class Refunded(val reason: RefundReason) : ProcessedPaymentState
+
+        data class Failed(val reason: String?) : ProcessedPaymentState
 
         object InProgress : ProcessedPaymentState
     }

--- a/src/main/kotlin/com/example/giftsbot/telegram/TelegramApiClient.kt
+++ b/src/main/kotlin/com/example/giftsbot/telegram/TelegramApiClient.kt
@@ -225,6 +225,30 @@ class TelegramApiClient(
         }
     }
 
+    suspend fun refundStarPayment(
+        userId: Long,
+        telegramPaymentChargeId: String,
+    ) {
+        val normalizedChargeId = telegramPaymentChargeId.trim()
+        logger.debug(
+            "refundStarPayment request userId={} chargeId={}",
+            userId,
+            normalizedChargeId,
+        )
+        val result =
+            execute<Boolean>(
+                methodName = "refundStarPayment",
+                body =
+                    RefundStarPaymentRequest(
+                        userId = userId,
+                        telegramPaymentChargeId = normalizedChargeId,
+                    ),
+            )
+        if (!result) {
+            throw TelegramApiException("Telegram API refundStarPayment returned false result")
+        }
+    }
+
     suspend fun giftPremiumSubscription(
         userId: Long,
         monthCount: Int,
@@ -453,6 +477,14 @@ private data class SendGiftRequest(
     val giftId: String,
     @SerialName("pay_for_upgrade")
     val payForUpgrade: Boolean? = null,
+)
+
+@Serializable
+private data class RefundStarPaymentRequest(
+    @SerialName("user_id")
+    val userId: Long,
+    @SerialName("telegram_payment_charge_id")
+    val telegramPaymentChargeId: String,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary
- add a dedicated `RefundService` that calls Telegram's `refundStarPayment`, tracks audit state, and emits refund metrics
- trigger refunds from payment validation, RNG, and award failures while making refund reasons explicit
- register the refund service in the bootstrap flow and expose the Bot API helper for star-payment refunds

## Testing
- `./gradlew ktlintCheck detekt` *(fails: existing style violations reported in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d745c630908321b353a71862121228