### PR TITLE
Add mini app invoice flow

### DIFF
--- a/miniapp/src/lib/pay.ts
+++ b/miniapp/src/lib/pay.ts
@@ -1,0 +1,46 @@
+import { initializeTelegramWebApp } from './tg';
+
+export type InvoiceStatus = 'paid' | 'cancelled' | 'failed';
+
+export const openInvoice = async (invoiceLink: string): Promise<InvoiceStatus> => {
+  const webApp = initializeTelegramWebApp();
+  if (!webApp || typeof webApp.openInvoice !== 'function') {
+    throw new Error('Платежи Telegram недоступны в этом окружении');
+  }
+
+  return await new Promise<InvoiceStatus>((resolve, reject) => {
+    let settled = false;
+    const resolveOnce = (status: InvoiceStatus) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(status);
+    };
+
+    const handleReject = (reason: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(
+        reason instanceof Error
+          ? reason
+          : new Error('Не удалось открыть окно платежа в Telegram')
+      );
+    };
+
+    try {
+      const openResult = webApp.openInvoice(invoiceLink, resolveOnce);
+      Promise.resolve(openResult)
+        .then((opened) => {
+          if (opened === false) {
+            handleReject(new Error('Не удалось открыть окно платежа в Telegram'));
+          }
+        })
+        .catch(handleReject);
+    } catch (error) {
+      handleReject(error);
+    }
+  });
+};

--- a/miniapp/src/lib/tg.ts
+++ b/miniapp/src/lib/tg.ts
@@ -20,6 +20,10 @@ export interface TelegramWebApp {
   isExpanded: boolean;
   onEvent(eventType: 'themeChanged', eventHandler: () => void): void;
   offEvent(eventType: 'themeChanged', eventHandler: () => void): void;
+  openInvoice(
+    slug: string,
+    callback?: (status: 'paid' | 'cancelled' | 'failed') => void
+  ): boolean | Promise<boolean>;
 }
 
 declare global {

--- a/miniapp/src/styles.css
+++ b/miniapp/src/styles.css
@@ -264,8 +264,16 @@ h1 {
 
 .case-footer {
   display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.case-price-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
 }
 
 .case-price {
@@ -288,6 +296,68 @@ h1 {
 .case-price-hint {
   color: var(--tg-hint-color);
   font-size: 0.85rem;
+}
+
+.case-buy-button {
+  cursor: pointer;
+  border: none;
+  border-radius: 14px;
+  padding: 0.6rem 1.05rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: linear-gradient(
+    135deg,
+    var(--tg-button-color),
+    color-mix(in srgb, var(--tg-button-color) 65%, #ffffff 35%)
+  );
+  color: var(--tg-button-text-color);
+  transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--tg-button-color) 35%, transparent);
+  white-space: nowrap;
+}
+
+.case-buy-button:active {
+  transform: scale(0.97);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--tg-button-color) 35%, transparent);
+  filter: brightness(0.96);
+}
+
+.case-buy-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+  box-shadow: none;
+  filter: none;
+}
+
+.payment-status {
+  margin: 0;
+  padding: 0.9rem 1.1rem;
+  border-radius: 16px;
+  background-color: color-mix(in srgb, var(--tg-secondary-bg-color) 70%, transparent);
+  color: var(--tg-text-color);
+  font-size: 0.95rem;
+  line-height: 1.45;
+  transition: background-color 200ms ease, color 200ms ease;
+}
+
+.payment-status--loading {
+  color: var(--tg-hint-color);
+}
+
+.payment-status--paid {
+  background-color: color-mix(in srgb, #35b558 28%, transparent);
+  color: #06361c;
+}
+
+.payment-status--cancelled {
+  color: var(--tg-hint-color);
+}
+
+.payment-status--failed,
+.payment-status--error {
+  background-color: color-mix(in srgb, #ff4d4f 30%, transparent);
+  color: #2a0505;
 }
 
 @media (max-width: 720px) {

--- a/src/main/kotlin/com/example/app/payments/InvoiceRoutes.kt
+++ b/src/main/kotlin/com/example/app/payments/InvoiceRoutes.kt
@@ -1,0 +1,69 @@
+package com.example.app.payments
+
+import com.example.app.api.errorResponse
+import com.example.app.webapp.WebAppAuth
+import com.example.app.webapp.WebAppAuthPlugin
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
+import java.security.SecureRandom
+import java.util.Base64
+
+private const val NONCE_BYTES: Int = 16
+private val secureRandom: SecureRandom = SecureRandom()
+
+fun Route.registerMiniAppInvoiceRoutes(
+    botToken: String,
+    invoiceService: TelegramInvoiceService,
+) {
+    route("/api/miniapp") {
+        install(WebAppAuthPlugin) {
+            this.botToken = botToken
+        }
+
+        post("/invoice") {
+            val request = call.receive<CreateMiniAppInvoiceRequest>()
+            val caseId = request.caseId.trim()
+            if (caseId.isEmpty()) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    errorResponse(
+                        status = HttpStatusCode.BadRequest,
+                        reason = "invalid_case_id",
+                        message = "Case ID must not be blank",
+                        callId = call.callId,
+                    ),
+                )
+                return@post
+            }
+
+            val userId = call.attributes[WebAppAuth.UserIdKey]
+            val nonce = generateNonce()
+            val response =
+                invoiceService.createCaseInvoice(
+                    caseId = caseId,
+                    userId = userId,
+                    nonce = nonce,
+                )
+
+            call.respond(response)
+        }
+    }
+}
+
+@Serializable
+private data class CreateMiniAppInvoiceRequest(
+    val caseId: String,
+)
+
+private fun generateNonce(): String {
+    val buffer = ByteArray(NONCE_BYTES)
+    secureRandom.nextBytes(buffer)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(buffer)
+}


### PR DESCRIPTION
## Summary
- add a dedicated Ktor route for POST /api/miniapp/invoice that validates initData, generates a nonce, and calls TelegramInvoiceService
- wire invoice service creation into the application bootstrap so the route can create invoice links with the Telegram API
- extend the mini app to request invoices, open them in Telegram, and surface payment statuses with updated UI helpers and styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d757971e7c83219da6f042a2fc4b47