### PR TITLE
Refine payment services and format for detekt compliance

### DIFF
--- a/src/main/kotlin/com/example/app/payments/RefundService.kt
+++ b/src/main/kotlin/com/example/app/payments/RefundService.kt
@@ -43,7 +43,7 @@ class RefundService(
                 return
             }
             is BeginResult.Start -> {
-                executeRefund(userId, normalizedChargeId, reason, startDecision.attempt)
+                executeRefund(userId, normalizedChargeId, reason, startDecision.entry.attempt)
             }
         }
     }
@@ -83,8 +83,7 @@ class RefundService(
                 val duration = Duration.between(startedAt, clock.instant())
                 finishSuccess(chargeId, reason, attempt, duration)
                 logSuccess(userId, chargeId, reason, attempt, duration)
-            }
-            .onFailure { cause ->
+            }.onFailure { cause ->
                 finishFailure(chargeId, reason, attempt, cause)
                 logFailure(userId, chargeId, reason, attempt, cause)
                 throw cause
@@ -222,9 +221,13 @@ class RefundService(
     }
 
     private sealed interface BeginResult {
-        data class Start(val entry: RefundJournalEntry.InProgress) : BeginResult
+        data class Start(
+            val entry: RefundJournalEntry.InProgress,
+        ) : BeginResult
 
-        data class Skip(val previous: RefundJournalEntry?) : BeginResult
+        data class Skip(
+            val previous: RefundJournalEntry?,
+        ) : BeginResult
     }
 
     private sealed interface RefundJournalEntry {
@@ -264,15 +267,21 @@ sealed interface RefundReason {
     val code: String
     val detail: String?
 
-    data class Validation(override val detail: String) : RefundReason {
+    data class Validation(
+        override val detail: String,
+    ) : RefundReason {
         override val code: String = "validation_failure"
     }
 
-    data class Draw(override val detail: String) : RefundReason {
+    data class Draw(
+        override val detail: String,
+    ) : RefundReason {
         override val code: String = "draw_failure"
     }
 
-    data class Award(override val detail: String) : RefundReason {
+    data class Award(
+        override val detail: String,
+    ) : RefundReason {
         override val code: String = "award_failure"
     }
 }

--- a/src/main/kotlin/com/example/app/payments/SuccessfulPaymentHandler.kt
+++ b/src/main/kotlin/com/example/app/payments/SuccessfulPaymentHandler.kt
@@ -4,8 +4,6 @@ import com.example.app.observability.Metrics
 import com.example.app.observability.MetricsNames
 import com.example.app.observability.MetricsTags
 import com.example.app.payments.dto.PaymentPayload
-import com.example.app.payments.PaymentSupport
-import com.example.app.payments.RefundReason
 import com.example.giftsbot.economy.CasesRepository
 import com.example.giftsbot.rng.RngService
 import com.example.giftsbot.rng.buildUserReceiptText
@@ -14,187 +12,158 @@ import com.example.giftsbot.telegram.SuccessfulPaymentDto
 import com.example.giftsbot.telegram.TelegramApiClient
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CancellationException
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 class SuccessfulPaymentHandler(
     private val telegramApiClient: TelegramApiClient,
     private val rngService: RngService,
-    private val casesRepository: CasesRepository,
+    casesRepository: CasesRepository,
     private val awardService: AwardService,
     paymentSupport: PaymentSupport,
     meterRegistry: MeterRegistry,
 ) {
     private val refundService = paymentSupport.refundService
     private val paymentsConfig = paymentSupport.config
+    private val validator = PaymentValidator(casesRepository, paymentsConfig)
     private val metrics = SuccessfulPaymentMetrics(meterRegistry)
     private val processedPayments = ConcurrentHashMap<String, ProcessedPaymentState>()
 
-    suspend fun handle(updateId: Long, message: MessageDto) {
+    suspend fun handle(
+        updateId: Long,
+        message: MessageDto,
+    ) {
+        when (val decision = prepareProcessing(message)) {
+            is ProcessingDecision.Process ->
+                processPayment(updateId, message, decision)
+            is ProcessingDecision.ValidationFailed ->
+                handleValidationFailure(decision.chargeId, updateId, message, decision.failure)
+            is ProcessingDecision.Duplicate -> {
+                metrics.markIdempotent()
+                logDuplicate(logger, updateId, decision.chargeId, decision.previousState)
+            }
+            is ProcessingDecision.MissingPayment -> {
+                metrics.markFailure()
+                logMissingPayment(logger, updateId, decision.message)
+            }
+            is ProcessingDecision.BlankCharge -> {
+                metrics.markFailure()
+                logBlankCharge(logger, updateId, decision.message)
+            }
+        }
+    }
+
+    private fun prepareProcessing(message: MessageDto): ProcessingDecision {
         val payment = message.successful_payment
-        if (payment == null) {
-            metrics.markFailure()
-            logger.warn(
-                "successful payment missing: updateId={} messageId={} chatId={}",
-                updateId,
-                message.message_id,
-                message.chat.id,
-            )
-            return
-        }
-
-        val chargeId = payment.telegram_payment_charge_id.trim()
-        if (chargeId.isEmpty()) {
-            metrics.markFailure()
-            logger.warn(
-                "successful payment rejected: updateId={} reason={} messageId={} chatId={}",
-                updateId,
-                "charge_id_blank",
-                message.message_id,
-                message.chat.id,
-            )
-            return
-        }
-
-        val previousState = processedPayments.putIfAbsent(chargeId, ProcessedPaymentState.InProgress)
-        if (previousState != null) {
-            metrics.markIdempotent()
-            logDuplicate(updateId, chargeId, previousState)
-            return
-        }
-
-        val validation = validate(message, payment)
-        if (validation is ValidationResult.Failure) {
-            val refunded = refundAfterValidation(chargeId, validation)
-            processedPayments[chargeId] =
-                if (refunded) {
-                    ProcessedPaymentState.Refunded(RefundReason.Validation(validation.reason))
-                } else {
-                    ProcessedPaymentState.Failed(validation.reason)
+        val chargeId = payment?.telegram_payment_charge_id?.trim()?.takeIf { it.isNotEmpty() }
+        val previousState = chargeId?.let { processedPayments.putIfAbsent(it, ProcessedPaymentState.InProgress) }
+        return when {
+            payment == null -> ProcessingDecision.MissingPayment(message)
+            chargeId == null -> ProcessingDecision.BlankCharge(message)
+            previousState != null -> ProcessingDecision.Duplicate(chargeId, previousState)
+            else ->
+                when (val validation = validator.validate(message, payment)) {
+                    is ValidationResult.Success -> ProcessingDecision.Process(chargeId, payment, validation.payload)
+                    is ValidationResult.Failure -> ProcessingDecision.ValidationFailed(chargeId, validation)
                 }
-            metrics.markFailure()
-            logValidationFailure(updateId, chargeId, message, validation)
-            return
         }
+    }
 
-        val payload = (validation as ValidationResult.Success).payload
-        val providerChargeId = payment.provider_payment_charge_id?.trim()?.takeUnless { it.isEmpty() }
-
+    private suspend fun processPayment(
+        updateId: Long,
+        message: MessageDto,
+        decision: ProcessingDecision.Process,
+    ) {
         var plan: AwardPlan? = null
         var awardAttempted = false
-        try {
-            val drawResult = rngService.draw(payload.caseId, payload.userId, payload.nonce)
-            plan =
-                AwardPlan(
-                    telegramPaymentChargeId = chargeId,
-                    providerPaymentChargeId = providerChargeId,
-                    totalAmount = payment.total_amount,
-                    currency = payment.currency,
-                    userId = payload.userId,
-                    caseId = payload.caseId,
-                    nonce = payload.nonce,
-                    resultItemId = drawResult.record.resultItemId,
-                    rngRecord = drawResult.record,
-                    rngReceipt = drawResult.receipt,
-                )
-
-            awardAttempted = true
-            awardService.schedule(plan)
-            processedPayments[chargeId] = ProcessedPaymentState.Completed(plan)
+        val outcome =
+            runCatching {
+                plan = createPlan(decision.chargeId, decision.payment, decision.payload)
+                awardAttempted = true
+                val createdPlan = plan!!
+                awardService.schedule(createdPlan)
+                createdPlan
+            }
+        outcome.onSuccess { createdPlan ->
+            processedPayments[decision.chargeId] = ProcessedPaymentState.Completed(createdPlan)
             metrics.markSuccess()
-            logger.info(
-                "successful payment processed: updateId={} chargeId={} userId={} caseId={} amount={} resultItemId={}",
-                updateId,
-                chargeId,
-                plan.userId,
-                plan.caseId,
-                plan.totalAmount,
-                plan.resultItemId ?: "-",
-            )
-            sendReceiptIfEnabled(updateId, message, plan)
-        } catch (cause: Throwable) {
-            if (cause is CancellationException) {
-                processedPayments.remove(chargeId, ProcessedPaymentState.InProgress)
-                throw cause
-            }
-            val detail = failureDetail(cause)
-            val refundReason = if (awardAttempted && plan != null) {
-                RefundReason.Award(detail)
-            } else {
-                RefundReason.Draw(detail)
-            }
-            val refundCurrency = plan?.currency ?: payment.currency
-            val refundUserId = plan?.userId ?: payload.userId
-            val refunded = attemptRefund(chargeId, refundUserId, refundCurrency, refundReason)
-            processedPayments[chargeId] =
-                if (refunded) {
-                    ProcessedPaymentState.Refunded(refundReason)
-                } else {
-                    ProcessedPaymentState.Failed(refundReason.detail)
-                }
-            metrics.markFailure()
-            logger.error(
-                "successful payment failed: updateId={} chargeId={} userId={} caseId={}",
-                updateId,
-                chargeId,
-                payload.userId,
-                payload.caseId,
-                cause,
-            )
+            logSuccess(logger, updateId, createdPlan)
+            sendReceiptIfEnabled(updateId, message, createdPlan)
+        }
+        outcome.exceptionOrNull()?.let { cause ->
+            handleProcessingFailure(updateId, decision, plan, awardAttempted, cause)
             throw cause
         }
     }
 
-    private fun validate(
-        message: MessageDto,
+    private fun createPlan(
+        chargeId: String,
         payment: SuccessfulPaymentDto,
-    ): ValidationResult {
-        val payloadResult = runCatching { PaymentPayload.decode(payment.invoice_payload) }
-        val payload = payloadResult.getOrElse { cause ->
-            val context = message.from?.id?.takeIf { it > 0 }?.let { RefundContext(userId = it, currency = payment.currency) }
-            return ValidationResult.Failure("invalid_payload", cause, context)
-        }
-        val refundContext = RefundContext(userId = payload.userId, currency = payment.currency)
+        payload: PaymentPayload,
+    ): AwardPlan {
+        val drawResult = rngService.draw(payload.caseId, payload.userId, payload.nonce)
+        val providerChargeId = payment.provider_payment_charge_id?.trim()?.takeUnless { it.isEmpty() }
+        return AwardPlan(
+            telegramPaymentChargeId = chargeId,
+            providerPaymentChargeId = providerChargeId,
+            totalAmount = payment.total_amount,
+            currency = payment.currency,
+            userId = payload.userId,
+            caseId = payload.caseId,
+            nonce = payload.nonce,
+            resultItemId = drawResult.record.resultItemId,
+            rngRecord = drawResult.record,
+            rngReceipt = drawResult.receipt,
+        )
+    }
 
-        val chatId = message.chat.id
-        val fromId = message.from?.id
-        if (payload.userId != chatId) {
-            return ValidationResult.Failure(
-                "user_mismatch expected=${payload.userId} actual=$chatId",
-                refundContext = refundContext,
-            )
+    private suspend fun handleProcessingFailure(
+        updateId: Long,
+        decision: ProcessingDecision.Process,
+        plan: AwardPlan?,
+        awardAttempted: Boolean,
+        cause: Throwable,
+    ) {
+        if (cause is CancellationException) {
+            processedPayments.remove(decision.chargeId, ProcessedPaymentState.InProgress)
+            throw cause
         }
-        if (fromId != null && fromId != payload.userId) {
-            return ValidationResult.Failure(
-                "sender_mismatch expected=${payload.userId} actual=$fromId",
-                refundContext = refundContext,
-            )
-        }
-        if (payload.nonce.isBlank()) {
-            return ValidationResult.Failure("nonce_blank", refundContext = refundContext)
-        }
-        if (payload.caseId.isBlank()) {
-            return ValidationResult.Failure("case_id_blank", refundContext = refundContext)
-        }
+        val detail = exceptionDetail(cause)
+        val refundReason =
+            if (awardAttempted && plan != null) {
+                RefundReason.Award(detail)
+            } else {
+                RefundReason.Draw(detail)
+            }
+        val refundCurrency = plan?.currency ?: decision.payment.currency
+        val refundUserId = plan?.userId ?: decision.payload.userId
+        val refunded = attemptRefund(decision.chargeId, refundUserId, refundCurrency, refundReason)
+        processedPayments[decision.chargeId] =
+            if (refunded) {
+                ProcessedPaymentState.Refunded(refundReason)
+            } else {
+                ProcessedPaymentState.Failed(refundReason.detail)
+            }
+        metrics.markFailure()
+        logProcessingFailure(logger, updateId, decision, refundUserId, cause)
+    }
 
-        if (!payment.currency.equals(paymentsConfig.currency, ignoreCase = false)) {
-            return ValidationResult.Failure(
-                "invalid_currency expected=${paymentsConfig.currency} actual=${payment.currency}",
-                refundContext = refundContext,
-            )
-        }
-
-        val case = casesRepository.get(payload.caseId)
-            ?: return ValidationResult.Failure("case_not_found caseId=${payload.caseId}", refundContext = refundContext)
-
-        if (payment.total_amount != case.priceStars) {
-            return ValidationResult.Failure(
-                "invalid_amount expected=${case.priceStars} actual=${payment.total_amount}",
-                refundContext = refundContext,
-            )
-        }
-
-        return ValidationResult.Success(payload = payload)
+    private suspend fun handleValidationFailure(
+        chargeId: String,
+        updateId: Long,
+        message: MessageDto,
+        failure: ValidationResult.Failure,
+    ) {
+        val refunded = refundAfterValidation(chargeId, failure)
+        processedPayments[chargeId] =
+            if (refunded) {
+                ProcessedPaymentState.Refunded(RefundReason.Validation(failure.reason))
+            } else {
+                ProcessedPaymentState.Failed(failure.reason)
+            }
+        metrics.markFailure()
+        logValidationFailure(logger, updateId, chargeId, message, failure)
     }
 
     private suspend fun refundAfterValidation(
@@ -262,9 +231,6 @@ class SuccessfulPaymentHandler(
         }.isSuccess
     }
 
-    private fun failureDetail(cause: Throwable): String =
-        cause.message?.takeIf { it.isNotBlank() } ?: cause.javaClass.simpleName
-
     private suspend fun sendReceiptIfEnabled(
         updateId: Long,
         message: MessageDto,
@@ -282,109 +248,15 @@ class SuccessfulPaymentHandler(
                 replyToMessageId = message.message_id,
             )
         }.onSuccess {
-            logger.info(
-                "successful payment receipt sent: updateId={} chargeId={} chatId={} messageId={} textLength={}",
-                updateId,
-                plan.telegramPaymentChargeId,
-                message.chat.id,
-                message.message_id,
-                text.length,
-            )
+            logReceiptSuccess(logger, updateId, plan, message, text.length)
         }.onFailure { cause ->
-            logger.warn(
-                "successful payment receipt failed: updateId={} chargeId={} chatId={} messageId={} reason={}",
-                updateId,
-                plan.telegramPaymentChargeId,
-                message.chat.id,
-                message.message_id,
-                cause.message,
-                cause,
-            )
+            logReceiptFailure(logger, updateId, plan, message, cause)
         }
     }
 
-    private fun logDuplicate(
-        updateId: Long,
-        chargeId: String,
-        state: ProcessedPaymentState,
+    private class SuccessfulPaymentMetrics(
+        registry: MeterRegistry,
     ) {
-        when (state) {
-            is ProcessedPaymentState.Completed -> {
-                val plan = state.plan
-                logger.info(
-                    "successful payment duplicate: updateId={} chargeId={} userId={} caseId={}",
-                    updateId,
-                    chargeId,
-                    plan.userId,
-                    plan.caseId,
-                )
-            }
-            is ProcessedPaymentState.Refunded -> {
-                if (state.reason.detail != null) {
-                    logger.info(
-                        "successful payment duplicate refunded: updateId={} chargeId={} reason={} detail={}",
-                        updateId,
-                        chargeId,
-                        state.reason.code,
-                        state.reason.detail,
-                    )
-                } else {
-                    logger.info(
-                        "successful payment duplicate refunded: updateId={} chargeId={} reason={}",
-                        updateId,
-                        chargeId,
-                        state.reason.code,
-                    )
-                }
-            }
-            is ProcessedPaymentState.Failed -> {
-                logger.info(
-                    "successful payment duplicate failed: updateId={} chargeId={} reason={}",
-                    updateId,
-                    chargeId,
-                    state.reason ?: "-",
-                )
-            }
-            ProcessedPaymentState.InProgress -> {
-                logger.info(
-                    "successful payment duplicate: updateId={} chargeId={} state=in_progress",
-                    updateId,
-                    chargeId,
-                )
-            }
-        }
-    }
-
-    private fun logValidationFailure(
-        updateId: Long,
-        chargeId: String,
-        message: MessageDto,
-        failure: ValidationResult.Failure,
-    ) {
-        val cause = failure.cause
-        if (cause != null) {
-            logger.warn(
-                "successful payment rejected: updateId={} chargeId={} messageId={} chatId={} reason={}",
-                updateId,
-                chargeId,
-                message.message_id,
-                message.chat.id,
-                failure.reason,
-                cause,
-            )
-        } else {
-            logger.warn(
-                "successful payment rejected: updateId={} chargeId={} messageId={} chatId={} reason={}",
-                updateId,
-                chargeId,
-                message.message_id,
-                message.chat.id,
-                failure.reason,
-            )
-        }
-    }
-
-    private class SuccessfulPaymentMetrics(registry: MeterRegistry) {
         private val componentTag = MetricsTags.COMPONENT to COMPONENT_VALUE
         private val successCounter =
             Metrics.counter(registry, MetricsNames.PAY_SUCCESS_TOTAL, componentTag)
@@ -406,33 +278,341 @@ class SuccessfulPaymentHandler(
         }
     }
 
-    private sealed interface ValidationResult {
-        data class Success(val payload: PaymentPayload) : ValidationResult
-
-        data class Failure(
-            val reason: String,
-            val cause: Throwable? = null,
-            val refundContext: RefundContext? = null,
-        ) : ValidationResult
-    }
-
-    private data class RefundContext(
-        val userId: Long,
-        val currency: String,
-    )
-
-    private sealed interface ProcessedPaymentState {
-        data class Completed(val plan: AwardPlan) : ProcessedPaymentState
-
-        data class Refunded(val reason: RefundReason) : ProcessedPaymentState
-
-        data class Failed(val reason: String?) : ProcessedPaymentState
-
-        object InProgress : ProcessedPaymentState
-    }
-
     companion object {
         private const val COMPONENT_VALUE = "payments"
-        private val logger = LoggerFactory.getLogger(SuccessfulPaymentHandler::class.java)
+        private val logger: Logger = LoggerFactory.getLogger(SuccessfulPaymentHandler::class.java)
     }
+}
+
+private class PaymentValidator(
+    private val casesRepository: CasesRepository,
+    private val paymentsConfig: PaymentsConfig,
+) {
+    fun validate(
+        message: MessageDto,
+        payment: SuccessfulPaymentDto,
+    ): ValidationResult {
+        val payloadResult = decodePayload(message, payment)
+        if (payloadResult is ValidationResult.Failure) {
+            return payloadResult
+        }
+        val payload = (payloadResult as ValidationResult.Success).payload
+        val context = RefundContext(userId = payload.userId, currency = payment.currency)
+        val failure =
+            validateMessageContext(message, payload, context)
+                ?: validateCurrency(payment.currency, context)
+                ?: validateCase(payload, payment.total_amount, context)
+        return failure ?: ValidationResult.Success(payload)
+    }
+
+    private fun decodePayload(
+        message: MessageDto,
+        payment: SuccessfulPaymentDto,
+    ): ValidationResult {
+        val result = runCatching { PaymentPayload.decode(payment.invoice_payload) }
+        val payload = result.getOrNull()
+        if (payload != null) {
+            return ValidationResult.Success(payload)
+        }
+        val refundContext =
+            message.from
+                ?.id
+                ?.takeIf { it > 0 }
+                ?.let { RefundContext(userId = it, currency = payment.currency) }
+        return ValidationResult.Failure(
+            reason = "invalid_payload",
+            cause = result.exceptionOrNull(),
+            refundContext = refundContext,
+        )
+    }
+
+    private fun validateMessageContext(
+        message: MessageDto,
+        payload: PaymentPayload,
+        context: RefundContext,
+    ): ValidationResult.Failure? {
+        val fromId = message.from?.id
+        val reason =
+            when {
+                payload.userId != message.chat.id ->
+                    "user_mismatch expected=${payload.userId} actual=${message.chat.id}"
+                fromId != null && fromId != payload.userId ->
+                    "sender_mismatch expected=${payload.userId} actual=$fromId"
+                payload.nonce.isBlank() -> "nonce_blank"
+                payload.caseId.isBlank() -> "case_id_blank"
+                else -> null
+            } ?: return null
+        return ValidationResult.Failure(reason = reason, refundContext = context)
+    }
+
+    private fun validateCurrency(
+        paymentCurrency: String,
+        context: RefundContext,
+    ): ValidationResult.Failure? =
+        if (!paymentCurrency.equals(paymentsConfig.currency, ignoreCase = false)) {
+            ValidationResult.Failure(
+                reason = "invalid_currency expected=${paymentsConfig.currency} actual=$paymentCurrency",
+                refundContext = context,
+            )
+        } else {
+            null
+        }
+
+    private fun validateCase(
+        payload: PaymentPayload,
+        totalAmount: Long,
+        context: RefundContext,
+    ): ValidationResult.Failure? {
+        val case = casesRepository.get(payload.caseId)
+        val priceStars = case?.priceStars
+        val reason =
+            when {
+                case == null -> "case_not_found caseId=${payload.caseId}"
+                priceStars != null && totalAmount != priceStars ->
+                    "invalid_amount expected=$priceStars actual=$totalAmount"
+                else -> null
+            } ?: return null
+        return ValidationResult.Failure(reason = reason, refundContext = context)
+    }
+}
+
+private sealed interface ProcessingDecision {
+    data class Process(
+        val chargeId: String,
+        val payment: SuccessfulPaymentDto,
+        val payload: PaymentPayload,
+    ) : ProcessingDecision
+
+    data class ValidationFailed(
+        val chargeId: String,
+        val failure: ValidationResult.Failure,
+    ) : ProcessingDecision
+
+    data class Duplicate(
+        val chargeId: String,
+        val previousState: ProcessedPaymentState,
+    ) : ProcessingDecision
+
+    data class MissingPayment(
+        val message: MessageDto,
+    ) : ProcessingDecision
+
+    data class BlankCharge(
+        val message: MessageDto,
+    ) : ProcessingDecision
+}
+
+private sealed interface ValidationResult {
+    data class Success(
+        val payload: PaymentPayload,
+    ) : ValidationResult
+
+    data class Failure(
+        val reason: String,
+        val cause: Throwable? = null,
+        val refundContext: RefundContext? = null,
+    ) : ValidationResult
+}
+
+private data class RefundContext(
+    val userId: Long,
+    val currency: String,
+)
+
+private sealed interface ProcessedPaymentState {
+    data class Completed(
+        val plan: AwardPlan,
+    ) : ProcessedPaymentState
+
+    data class Refunded(
+        val reason: RefundReason,
+    ) : ProcessedPaymentState
+
+    data class Failed(
+        val reason: String?,
+    ) : ProcessedPaymentState
+
+    object InProgress : ProcessedPaymentState
+}
+
+private fun exceptionDetail(cause: Throwable): String =
+    cause.message?.takeIf { it.isNotBlank() } ?: cause.javaClass.simpleName
+
+private fun logMissingPayment(
+    logger: Logger,
+    updateId: Long,
+    message: MessageDto,
+) {
+    logger.warn(
+        "successful payment missing: updateId={} messageId={} chatId={}",
+        updateId,
+        message.message_id,
+        message.chat.id,
+    )
+}
+
+private fun logBlankCharge(
+    logger: Logger,
+    updateId: Long,
+    message: MessageDto,
+) {
+    logger.warn(
+        "successful payment rejected: updateId={} reason={} messageId={} chatId={}",
+        updateId,
+        "charge_id_blank",
+        message.message_id,
+        message.chat.id,
+    )
+}
+
+private fun logSuccess(
+    logger: Logger,
+    updateId: Long,
+    plan: AwardPlan,
+) {
+    logger.info(
+        "successful payment processed: updateId={} chargeId={} userId={} caseId={} amount={} resultItemId={}",
+        updateId,
+        plan.telegramPaymentChargeId,
+        plan.userId,
+        plan.caseId,
+        plan.totalAmount,
+        plan.resultItemId ?: "-",
+    )
+}
+
+private fun logProcessingFailure(
+    logger: Logger,
+    updateId: Long,
+    decision: ProcessingDecision.Process,
+    userId: Long,
+    cause: Throwable,
+) {
+    logger.error(
+        "successful payment failed: updateId={} chargeId={} userId={} caseId={}",
+        updateId,
+        decision.chargeId,
+        userId,
+        decision.payload.caseId,
+        cause,
+    )
+}
+
+private fun logDuplicate(
+    logger: Logger,
+    updateId: Long,
+    chargeId: String,
+    state: ProcessedPaymentState,
+) {
+    when (state) {
+        is ProcessedPaymentState.Completed -> {
+            val plan = state.plan
+            logger.info(
+                "successful payment duplicate: updateId={} chargeId={} userId={} caseId={}",
+                updateId,
+                chargeId,
+                plan.userId,
+                plan.caseId,
+            )
+        }
+        is ProcessedPaymentState.Refunded -> {
+            val detail = state.reason.detail
+            if (detail != null) {
+                logger.info(
+                    "successful payment duplicate refunded: updateId={} chargeId={} reason={} detail={}",
+                    updateId,
+                    chargeId,
+                    state.reason.code,
+                    detail,
+                )
+            } else {
+                logger.info(
+                    "successful payment duplicate refunded: updateId={} chargeId={} reason={}",
+                    updateId,
+                    chargeId,
+                    state.reason.code,
+                )
+            }
+        }
+        is ProcessedPaymentState.Failed -> {
+            logger.info(
+                "successful payment duplicate failed: updateId={} chargeId={} reason={}",
+                updateId,
+                chargeId,
+                state.reason ?: "-",
+            )
+        }
+        ProcessedPaymentState.InProgress -> {
+            logger.info(
+                "successful payment duplicate: updateId={} chargeId={} state=in_progress",
+                updateId,
+                chargeId,
+            )
+        }
+    }
+}
+
+private fun logValidationFailure(
+    logger: Logger,
+    updateId: Long,
+    chargeId: String,
+    message: MessageDto,
+    failure: ValidationResult.Failure,
+) {
+    val cause = failure.cause
+    if (cause != null) {
+        logger.warn(
+            "successful payment rejected: updateId={} chargeId={} messageId={} chatId={} reason={}",
+            updateId,
+            chargeId,
+            message.message_id,
+            message.chat.id,
+            failure.reason,
+            cause,
+        )
+    } else {
+        logger.warn(
+            "successful payment rejected: updateId={} chargeId={} messageId={} chatId={} reason={}",
+            updateId,
+            chargeId,
+            message.message_id,
+            message.chat.id,
+            failure.reason,
+        )
+    }
+}
+
+private fun logReceiptSuccess(
+    logger: Logger,
+    updateId: Long,
+    plan: AwardPlan,
+    message: MessageDto,
+    textLength: Int,
+) {
+    logger.info(
+        "successful payment receipt sent: updateId={} chargeId={} chatId={} messageId={} textLength={}",
+        updateId,
+        plan.telegramPaymentChargeId,
+        message.chat.id,
+        message.message_id,
+        textLength,
+    )
+}
+
+private fun logReceiptFailure(
+    logger: Logger,
+    updateId: Long,
+    plan: AwardPlan,
+    message: MessageDto,
+    cause: Throwable,
+) {
+    logger.warn(
+        "successful payment receipt failed: updateId={} chargeId={} chatId={} messageId={} reason={}",
+        updateId,
+        plan.telegramPaymentChargeId,
+        message.chat.id,
+        message.message_id,
+        cause.message,
+        cause,
+    )
 }

--- a/src/main/kotlin/com/example/app/telegram/TelegramIntegrationConfig.kt
+++ b/src/main/kotlin/com/example/app/telegram/TelegramIntegrationConfig.kt
@@ -1,0 +1,91 @@
+package com.example.app.telegram
+
+import com.example.app.util.configValue
+import io.ktor.server.application.Application
+
+internal data class TelegramIntegrationConfig(
+    val botToken: String,
+    val mode: TelegramMode,
+    val webhookPath: String,
+    val webhookSecretToken: String,
+    val adminToken: String?,
+    val publicBaseUrl: String?,
+)
+
+internal enum class TelegramMode {
+    WEBHOOK,
+    LONG_POLLING,
+}
+
+internal fun TelegramMode.logValue(): String =
+    when (this) {
+        TelegramMode.WEBHOOK -> "webhook"
+        TelegramMode.LONG_POLLING -> "long_polling"
+    }
+
+internal fun Application.loadTelegramIntegrationConfig(): TelegramIntegrationConfig {
+    val botToken =
+        configValue(
+            propertyKeys = listOf("bot.token", "telegram.bot.token"),
+            envKeys = listOf("BOT_TOKEN", "TELEGRAM_BOT_TOKEN"),
+            configKeys = listOf("app.telegram.botToken", "telegram.botToken"),
+        )?.takeUnless { it.isBlank() }
+            ?: error("BOT_TOKEN is not configured.")
+
+    val mode =
+        parseMode(
+            configValue(
+                propertyKeys = listOf("bot.mode", "telegram.bot.mode"),
+                envKeys = listOf("BOT_MODE", "TELEGRAM_BOT_MODE"),
+                configKeys = listOf("app.telegram.mode", "telegram.mode"),
+            ),
+        )
+
+    val webhookPath =
+        configValue(
+            propertyKeys = listOf("telegram.webhookPath"),
+            envKeys = listOf("WEBHOOK_PATH"),
+            configKeys = listOf("app.telegram.webhookPath"),
+        )?.takeUnless { it.isBlank() }
+            ?: error("WEBHOOK_PATH is not configured.")
+
+    val webhookSecretToken =
+        configValue(
+            propertyKeys = listOf("telegram.webhookSecretToken"),
+            envKeys = listOf("WEBHOOK_SECRET_TOKEN"),
+            configKeys = listOf("app.telegram.webhookSecretToken"),
+        )?.takeUnless { it.isBlank() }
+            ?: error("WEBHOOK_SECRET_TOKEN is not configured.")
+
+    val adminToken =
+        configValue(
+            propertyKeys = listOf("admin.token"),
+            envKeys = listOf("ADMIN_TOKEN"),
+            configKeys = listOf("app.admin.token"),
+        )?.takeUnless { it.isBlank() }
+
+    val publicBaseUrl =
+        configValue(
+            propertyKeys = listOf("telegram.publicBaseUrl"),
+            envKeys = listOf("PUBLIC_BASE_URL"),
+            configKeys = listOf("app.telegram.publicBaseUrl"),
+        )?.takeUnless { it.isBlank() }
+
+    return TelegramIntegrationConfig(
+        botToken = botToken,
+        mode = mode,
+        webhookPath = webhookPath,
+        webhookSecretToken = webhookSecretToken,
+        adminToken = adminToken,
+        publicBaseUrl = publicBaseUrl,
+    )
+}
+
+private fun parseMode(rawMode: String?): TelegramMode {
+    val normalized = rawMode?.trim()?.lowercase()
+    return when (normalized) {
+        null, "", "webhook" -> TelegramMode.WEBHOOK
+        "long_polling", "long-polling" -> TelegramMode.LONG_POLLING
+        else -> error("Unsupported BOT_MODE value: $rawMode")
+    }
+}

--- a/src/main/kotlin/com/example/app/telegram/TelegramIntegrationFactory.kt
+++ b/src/main/kotlin/com/example/app/telegram/TelegramIntegrationFactory.kt
@@ -1,0 +1,74 @@
+package com.example.app.telegram
+
+import com.example.app.payments.AwardService
+import com.example.app.payments.GiftCatalogCache
+import com.example.app.payments.PaymentSupport
+import com.example.app.payments.PreCheckoutHandler
+import com.example.app.payments.RefundService
+import com.example.app.payments.SuccessfulPaymentHandler
+import com.example.app.payments.TelegramAwardService
+import com.example.app.payments.loadPaymentsConfig
+import com.example.app.rng.getRngService
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.telegram.TelegramApiClient
+import io.ktor.server.application.Application
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+internal fun createTelegramScope(): CoroutineScope =
+    CoroutineScope(SupervisorJob() + Dispatchers.IO + CoroutineName("telegram"))
+
+internal fun createAwardService(
+    api: TelegramApiClient,
+    casesRepository: CasesRepository,
+    refundService: RefundService,
+    meterRegistry: MeterRegistry,
+): AwardService {
+    val giftCatalogCache = GiftCatalogCache(api)
+    return TelegramAwardService(
+        telegramApiClient = api,
+        casesRepository = casesRepository,
+        giftCatalogCache = giftCatalogCache,
+        refundService = refundService,
+        meterRegistry = meterRegistry,
+    )
+}
+
+internal fun Application.createSuccessfulPaymentHandler(
+    api: TelegramApiClient,
+    casesRepository: CasesRepository,
+    refundService: RefundService,
+    meterRegistry: MeterRegistry,
+): SuccessfulPaymentHandler {
+    val paymentsConfig = loadPaymentsConfig()
+    return SuccessfulPaymentHandler(
+        telegramApiClient = api,
+        rngService = getRngService(),
+        casesRepository = casesRepository,
+        awardService = createAwardService(api, casesRepository, refundService, meterRegistry),
+        paymentSupport = PaymentSupport(config = paymentsConfig, refundService = refundService),
+        meterRegistry = meterRegistry,
+    )
+}
+
+internal fun createPreCheckoutHandler(
+    api: TelegramApiClient,
+    casesRepository: CasesRepository,
+    meterRegistry: MeterRegistry,
+): PreCheckoutHandler = PreCheckoutHandler(api, casesRepository, meterRegistry)
+
+internal fun createDispatcher(
+    scope: CoroutineScope,
+    meterRegistry: MeterRegistry,
+    router: WebhookUpdateRouter,
+    settings: UpdateDispatcherSettings,
+): UpdateDispatcher =
+    UpdateDispatcher(
+        scope = scope,
+        meterRegistry = meterRegistry,
+        settings = settings,
+        handleUpdate = router::route,
+    )

--- a/src/main/kotlin/com/example/app/telegram/WebhookUpdateRouter.kt
+++ b/src/main/kotlin/com/example/app/telegram/WebhookUpdateRouter.kt
@@ -12,11 +12,12 @@ class WebhookUpdateRouter(
         when (incoming) {
             is IncomingUpdate.SuccessfulPaymentUpdate -> handleSuccessfulPayment(incoming)
             is IncomingUpdate.PreCheckoutQueryUpdate -> handlePreCheckout(incoming)
-            else -> logger.debug(
-                "no handler for updateId={} type={}",
-                incoming.updateId,
-                incoming::class.simpleName,
-            )
+            else ->
+                logger.debug(
+                    "no handler for updateId={} type={}",
+                    incoming.updateId,
+                    incoming::class.simpleName,
+                )
         }
     }
 

--- a/src/test/kotlin/com/example/app/payments/PaymentsFlowTest.kt
+++ b/src/test/kotlin/com/example/app/payments/PaymentsFlowTest.kt
@@ -1,0 +1,242 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.app.payments.AwardPlan
+import com.example.app.payments.dto.PaymentPayload
+import com.example.giftsbot.economy.CaseConfig
+import com.example.giftsbot.economy.CaseSlotType
+import com.example.giftsbot.economy.CasesRepository
+import com.example.giftsbot.economy.PrizeItemConfig
+import com.example.giftsbot.rng.RngDrawRecord
+import com.example.giftsbot.rng.RngDrawResult
+import com.example.giftsbot.rng.RngReceipt
+import com.example.giftsbot.rng.RngService
+import com.example.giftsbot.telegram.ChatDto
+import com.example.giftsbot.telegram.CreateInvoiceLinkRequest
+import com.example.giftsbot.telegram.MessageDto
+import com.example.giftsbot.telegram.PreCheckoutQueryDto
+import com.example.giftsbot.telegram.SuccessfulPaymentDto
+import com.example.giftsbot.telegram.TelegramApiClient
+import com.example.giftsbot.telegram.UserDto
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class PaymentsFlowTest {
+    @MockK
+    private lateinit var telegramApiClient: TelegramApiClient
+
+    @MockK
+    private lateinit var casesRepository: CasesRepository
+
+    @MockK
+    private lateinit var rngService: RngService
+
+    @MockK
+    private lateinit var awardService: AwardService
+
+    @MockK
+    private lateinit var refundService: RefundService
+
+    private lateinit var meterRegistry: MeterRegistry
+    private lateinit var invoiceService: TelegramInvoiceService
+    private lateinit var preCheckoutHandler: PreCheckoutHandler
+    private lateinit var successfulPaymentHandler: SuccessfulPaymentHandler
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        meterRegistry = SimpleMeterRegistry()
+        val paymentsConfig =
+            PaymentsConfig(
+                currency = STARS_CURRENCY_CODE,
+                titlePrefix = "Mega",
+                receiptEnabled = true,
+                businessConnectionId = null,
+            )
+        invoiceService = TelegramInvoiceService(casesRepository, telegramApiClient, paymentsConfig)
+        preCheckoutHandler = PreCheckoutHandler(telegramApiClient, casesRepository, meterRegistry)
+        successfulPaymentHandler =
+            SuccessfulPaymentHandler(
+                telegramApiClient = telegramApiClient,
+                rngService = rngService,
+                casesRepository = casesRepository,
+                awardService = awardService,
+                paymentSupport = PaymentSupport(config = paymentsConfig, refundService = refundService),
+                meterRegistry = meterRegistry,
+            )
+    }
+
+    @Test
+    fun `invoice creation and pre checkout approve`() =
+        runTest {
+            val case = defaultCase()
+            every { casesRepository.get(case.id) } returns case
+            val requestSlot = slot<CreateInvoiceLinkRequest>()
+            coEvery { telegramApiClient.createInvoiceLink(capture(requestSlot)) } returns "https://t.me/invoice/abc"
+            coEvery { telegramApiClient.answerPreCheckoutQuery(any(), any(), any()) } returns true
+
+            val response = invoiceService.createCaseInvoice(case.id, userId = 42, nonce = "nonce-1")
+            assertEquals("https://t.me/invoice/abc", response.invoiceLink)
+            assertEquals(response.payload, requestSlot.captured.payload)
+            assertEquals(
+                case.priceStars,
+                requestSlot.captured.prices
+                    .single()
+                    .amount,
+            )
+
+            val query =
+                PreCheckoutQueryDto(
+                    id = "query-1",
+                    from = user(42),
+                    currency = STARS_CURRENCY_CODE,
+                    total_amount = case.priceStars,
+                    invoice_payload = response.payload,
+                )
+
+            val okBefore = metricCount(MetricsNames.PRE_CHECKOUT_TOTAL, MetricsTags.RESULT to "ok")
+            val failBefore = metricCount(MetricsNames.PRE_CHECKOUT_TOTAL, MetricsTags.RESULT to "fail")
+
+            preCheckoutHandler.handle(updateId = 100, query = query)
+
+            coVerify(exactly = 1) { telegramApiClient.answerPreCheckoutQuery(query.id, true, null) }
+            assertEquals(okBefore + 1.0, metricCount(MetricsNames.PRE_CHECKOUT_TOTAL, MetricsTags.RESULT to "ok"))
+            assertEquals(failBefore, metricCount(MetricsNames.PRE_CHECKOUT_TOTAL, MetricsTags.RESULT to "fail"))
+        }
+
+    @Test
+    fun `successful payment awards once and is idempotent`() =
+        runTest {
+            val case = defaultCase()
+            every { casesRepository.get(case.id) } returns case
+            val prizeId = case.items.first().id
+            val payload = PaymentPayload(caseId = case.id, userId = 900, nonce = "nonce-2", ts = 1L)
+            val drawRecord = rngRecord(case.id, payload.userId, payload.nonce, prizeId)
+            val receipt = rngReceipt()
+            every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
+            val planSlot = slot<AwardPlan>()
+            coEvery { awardService.schedule(capture(planSlot)) } returns Unit
+            coEvery {
+                telegramApiClient.sendMessage(
+                    chatId = payload.userId,
+                    text = any(),
+                    disableNotification = true,
+                    replyToMessageId = any(),
+                )
+            } returns receiptMessage(payload.userId)
+
+            val message = paymentMessage("charge-1", payload.encode(), payload.userId, case.priceStars)
+
+            val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
+            val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
+            val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
+
+            successfulPaymentHandler.handle(updateId = 200, message = message)
+            successfulPaymentHandler.handle(updateId = 201, message = message)
+
+            assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
+            assertEquals(idempotentBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
+            assertEquals(failBefore, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
+            coVerify(exactly = 1) { awardService.schedule(any()) }
+            val capturedPlan = planSlot.captured
+            assertNotNull(capturedPlan)
+            assertEquals("charge-1", capturedPlan.telegramPaymentChargeId)
+            assertEquals(payload.userId, capturedPlan.userId)
+            assertEquals(payload.caseId, capturedPlan.caseId)
+            assertEquals(payload.nonce, capturedPlan.nonce)
+            assertEquals(case.priceStars, capturedPlan.totalAmount)
+            assertEquals(STARS_CURRENCY_CODE, capturedPlan.currency)
+            assertEquals(drawRecord, capturedPlan.rngRecord)
+            assertEquals(receipt, capturedPlan.rngReceipt)
+        }
+
+    private fun metricCount(
+        name: String,
+        vararg tags: Pair<String, String>,
+    ): Double = Metrics.counter(meterRegistry, name, MetricsTags.COMPONENT to "payments", *tags).count()
+
+    private fun defaultCase(): CaseConfig =
+        CaseConfig(
+            id = "case",
+            title = "Case",
+            priceStars = 700,
+            rtpExtMin = 0.4,
+            rtpExtMax = 0.6,
+            jackpotAlpha = 0.01,
+            items =
+                listOf(
+                    PrizeItemConfig(
+                        id = "prize",
+                        type = CaseSlotType.GIFT,
+                        starCost = 700,
+                        probabilityPpm = 1_000_000,
+                    ),
+                ),
+        )
+
+    private fun user(id: Long): UserDto = UserDto(id = id, is_bot = false, first_name = "User")
+
+    private fun paymentMessage(
+        chargeId: String,
+        payload: String,
+        userId: Long,
+        totalAmount: Long,
+    ): MessageDto =
+        MessageDto(
+            message_id = 1,
+            date = 0,
+            chat = ChatDto(id = userId, type = "private"),
+            successful_payment =
+                SuccessfulPaymentDto(
+                    currency = STARS_CURRENCY_CODE,
+                    total_amount = totalAmount,
+                    invoice_payload = payload,
+                    telegram_payment_charge_id = chargeId,
+                    provider_payment_charge_id = "provider",
+                ),
+        )
+
+    private fun rngRecord(
+        caseId: String,
+        userId: Long,
+        nonce: String,
+        prizeId: String,
+    ): RngDrawRecord =
+        RngDrawRecord(
+            caseId = caseId,
+            userId = userId,
+            nonce = nonce,
+            serverSeedHash = "hash",
+            rollHex = "abcd",
+            ppm = 123,
+            resultItemId = prizeId,
+            createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+        )
+
+    private fun rngReceipt(): RngReceipt =
+        RngReceipt(
+            date = LocalDate.parse("2024-01-01"),
+            serverSeedHash = "hash",
+            clientSeed = "client",
+            rollHex = "abcd",
+            ppm = 123,
+        )
+
+    private fun receiptMessage(chatId: Long): MessageDto =
+        MessageDto(message_id = 10, date = 0, chat = ChatDto(id = chatId, type = "private"))
+}

--- a/src/test/kotlin/com/example/app/payments/PreCheckoutHandlerTest.kt
+++ b/src/test/kotlin/com/example/app/payments/PreCheckoutHandlerTest.kt
@@ -3,13 +3,13 @@ package com.example.app.payments
 import com.example.app.observability.Metrics
 import com.example.app.observability.MetricsNames
 import com.example.app.observability.MetricsTags
-import com.example.app.payments.dto.PaymentPayload
 import com.example.app.payments.STARS_CURRENCY_CODE
+import com.example.app.payments.dto.PaymentPayload
 import com.example.giftsbot.economy.CaseConfig
 import com.example.giftsbot.economy.CasesRepository
 import com.example.giftsbot.telegram.PreCheckoutQueryDto
-import com.example.giftsbot.telegram.UserDto
 import com.example.giftsbot.telegram.TelegramApiClient
+import com.example.giftsbot.telegram.UserDto
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/src/test/kotlin/com/example/app/payments/RefundServiceTest.kt
+++ b/src/test/kotlin/com/example/app/payments/RefundServiceTest.kt
@@ -1,0 +1,101 @@
+package com.example.app.payments
+
+import com.example.app.observability.Metrics
+import com.example.app.observability.MetricsNames
+import com.example.app.observability.MetricsTags
+import com.example.giftsbot.telegram.TelegramApiClient
+import com.example.giftsbot.telegram.TelegramApiException
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class RefundServiceTest {
+    @MockK
+    private lateinit var telegramApiClient: TelegramApiClient
+
+    private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var clock: Clock
+    private lateinit var refundService: RefundService
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        meterRegistry = SimpleMeterRegistry()
+        clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+        refundService = RefundService(telegramApiClient, meterRegistry, clock)
+    }
+
+    @Test
+    fun `successful refund recorded and idempotent`() =
+        runTest {
+            coEvery {
+                telegramApiClient.refundStarPayment(
+                    userId = 10,
+                    telegramPaymentChargeId = "charge",
+                )
+            } returns Unit
+            val successBefore = metricCount(MetricsNames.REFUND_TOTAL)
+            val failBefore = metricCount(MetricsNames.REFUND_FAIL_TOTAL)
+
+            refundService.refundStarPayment(
+                userId = 10,
+                telegramPaymentChargeId = "charge",
+                reason = RefundReason.Draw("test"),
+            )
+            refundService.refundStarPayment(
+                userId = 10,
+                telegramPaymentChargeId = "charge",
+                reason = RefundReason.Draw("test"),
+            )
+
+            assertEquals(successBefore + 1.0, metricCount(MetricsNames.REFUND_TOTAL))
+            assertEquals(failBefore, metricCount(MetricsNames.REFUND_FAIL_TOTAL))
+            coVerify(exactly = 1) { telegramApiClient.refundStarPayment(10, "charge") }
+        }
+
+    @Test
+    fun `failed refund increments metrics and retries succeed`() =
+        runTest {
+            coEvery {
+                telegramApiClient.refundStarPayment(
+                    userId = 20,
+                    telegramPaymentChargeId = "charge-2",
+                )
+            } throws TelegramApiException("502") andThen Unit
+            val successBefore = metricCount(MetricsNames.REFUND_TOTAL)
+            val failBefore = metricCount(MetricsNames.REFUND_FAIL_TOTAL)
+
+            assertFailsWith<TelegramApiException> {
+                refundService.refundStarPayment(
+                    userId = 20,
+                    telegramPaymentChargeId = "charge-2",
+                    reason = RefundReason.Validation("fail"),
+                )
+            }
+
+            assertEquals(failBefore + 1.0, metricCount(MetricsNames.REFUND_FAIL_TOTAL))
+            assertEquals(successBefore, metricCount(MetricsNames.REFUND_TOTAL))
+
+            refundService.refundStarPayment(
+                userId = 20,
+                telegramPaymentChargeId = "charge-2",
+                reason = RefundReason.Validation("fail"),
+            )
+
+            assertEquals(successBefore + 1.0, metricCount(MetricsNames.REFUND_TOTAL))
+            coVerify(exactly = 2) { telegramApiClient.refundStarPayment(20, "charge-2") }
+        }
+
+    private fun metricCount(name: String): Double =
+        Metrics.counter(meterRegistry, name, MetricsTags.COMPONENT to "payments").count()
+}

--- a/src/test/kotlin/com/example/app/payments/SuccessfulPaymentHandlerTest.kt
+++ b/src/test/kotlin/com/example/app/payments/SuccessfulPaymentHandlerTest.kt
@@ -21,9 +21,9 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.slot
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -45,49 +45,175 @@ class SuccessfulPaymentHandlerTest {
     @MockK
     private lateinit var awardService: AwardService
 
+    @MockK
+    private lateinit var refundService: RefundService
+
     private lateinit var meterRegistry: MeterRegistry
 
     private lateinit var handler: SuccessfulPaymentHandler
 
     @BeforeEach
     fun setUp() {
-        MockKAnnotations.init(this)
+        MockKAnnotations.init(this, relaxUnitFun = true)
         meterRegistry = SimpleMeterRegistry()
-        val paymentsConfig = PaymentsConfig(currency = STARS_CURRENCY_CODE, titlePrefix = null, receiptEnabled = true, businessConnectionId = null)
-        handler = SuccessfulPaymentHandler(
-            telegramApiClient = telegramApiClient,
-            rngService = rngService,
-            casesRepository = casesRepository,
-            awardService = awardService,
-            paymentsConfig = paymentsConfig,
-            meterRegistry = meterRegistry,
-        )
+        val paymentsConfig =
+            PaymentsConfig(
+                currency = STARS_CURRENCY_CODE,
+                titlePrefix = null,
+                receiptEnabled = true,
+                businessConnectionId = null,
+            )
+        val paymentSupport = PaymentSupport(config = paymentsConfig, refundService = refundService)
+        handler =
+            SuccessfulPaymentHandler(
+                telegramApiClient = telegramApiClient,
+                rngService = rngService,
+                casesRepository = casesRepository,
+                awardService = awardService,
+                paymentSupport = paymentSupport,
+                meterRegistry = meterRegistry,
+            )
+        coEvery { refundService.refundStarPayment(any(), any(), any()) } returns Unit
     }
 
     @Test
-    fun `handle successful payment builds plan and sends receipt`() = runTest {
-        val case = CaseConfig(
-            id = "case-1",
-            title = "Case 1",
-            priceStars = 100,
+    fun `handle successful payment builds plan and sends receipt`() =
+        runTest {
+            val case = giftCase(id = "case-1", priceStars = 100, prizeId = "item-1")
+            stubCase(case)
+            val payload = PaymentPayload(caseId = case.id, userId = 777, nonce = "nonce", ts = 1L)
+            val drawResult = rngResult(payload, resultItemId = "item-1", ppm = 123)
+            stubDraw(payload, drawResult)
+            stubSendMessage(payload.userId)
+            val planSlot = slot<AwardPlan>()
+            coEvery { awardService.schedule(capture(planSlot)) } returns Unit
+
+            val message =
+                paymentMessage(
+                    chargeId = "charge-1",
+                    payload = payload,
+                    totalAmount = case.priceStars,
+                    currency = STARS_CURRENCY_CODE,
+                )
+
+            val metricsBefore = metricsSnapshot()
+            handler.handle(updateId = 1L, message = message)
+
+            val capturedPlan = planSlot.captured
+            assertNotNull(capturedPlan)
+            assertPlanMatches(capturedPlan, payload, case.priceStars, drawResult, "charge-1")
+            metricsBefore.assertDelta(success = 1.0, idempotent = 0.0, failure = 0.0)
+            coVerify(exactly = 1) { awardService.schedule(any()) }
+            coVerify(exactly = 1) { telegramApiClient.sendMessage(payload.userId, any(), true, message.message_id) }
+        }
+
+    @Test
+    fun `duplicate payment is idempotent`() =
+        runTest {
+            val case = giftCase(id = "case-2", priceStars = 200, prizeId = "item-2")
+            stubCase(case)
+            val payload = PaymentPayload(caseId = case.id, userId = 900, nonce = "nonce", ts = 1L)
+            val drawResult = rngResult(payload, resultItemId = "item-2", ppm = 456)
+            stubDraw(payload, drawResult)
+            stubSendMessage(payload.userId)
+            coEvery { awardService.schedule(any()) } returns Unit
+
+            val message =
+                paymentMessage(
+                    chargeId = "charge-dup",
+                    payload = payload,
+                    totalAmount = case.priceStars,
+                    currency = STARS_CURRENCY_CODE,
+                )
+
+            val metricsBefore = metricsSnapshot()
+            handler.handle(updateId = 100L, message = message)
+            handler.handle(updateId = 101L, message = message)
+
+            metricsBefore.assertDelta(success = 1.0, idempotent = 1.0, failure = 0.0)
+            coVerify(exactly = 1) { awardService.schedule(any()) }
+            coVerify(exactly = 1) { telegramApiClient.sendMessage(payload.userId, any(), true, message.message_id) }
+        }
+
+    @Test
+    fun `validation failure is retriable`() =
+        runTest {
+            val case = giftCase(id = "case-3", priceStars = 300, prizeId = "item-3")
+            stubCase(case)
+            val payload = PaymentPayload(caseId = case.id, userId = 42, nonce = "nonce", ts = 1L)
+            val drawResult = rngResult(payload, resultItemId = null, ppm = 789)
+            stubDraw(payload, drawResult)
+            stubSendMessage(payload.userId)
+            coEvery { awardService.schedule(any()) } returns Unit
+
+            val invalidMessage =
+                paymentMessage(
+                    chargeId = "charge-retry",
+                    payload = payload,
+                    totalAmount = case.priceStars,
+                    currency = "USD",
+                )
+
+            val metricsBefore = metricsSnapshot()
+            handler.handle(updateId = 200L, message = invalidMessage)
+
+            metricsBefore.assertDelta(success = 0.0, idempotent = 0.0, failure = 1.0)
+            coVerify(exactly = 0) { awardService.schedule(any()) }
+            val afterInvalid = metricsSnapshot()
+
+            val validMessage =
+                paymentMessage(
+                    chargeId = "charge-retry-success",
+                    payload = payload,
+                    totalAmount = case.priceStars,
+                    currency = STARS_CURRENCY_CODE,
+                )
+
+            handler.handle(updateId = 201L, message = validMessage)
+
+            afterInvalid.assertDelta(success = 1.0, idempotent = 0.0, failure = 0.0)
+            coVerify(exactly = 1) { awardService.schedule(any()) }
+        }
+
+    private fun metricsSnapshot(): MetricsSnapshot =
+        MetricsSnapshot(
+            success = metricCount(MetricsNames.PAY_SUCCESS_TOTAL),
+            idempotent = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL),
+            failure = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL),
+        )
+
+    private fun metricCount(name: String): Double =
+        Metrics.counter(meterRegistry, name, MetricsTags.COMPONENT to "payments").count()
+
+    private fun giftCase(
+        id: String,
+        priceStars: Long,
+        prizeId: String,
+    ): CaseConfig =
+        CaseConfig(
+            id = id,
+            title = "Case $id",
+            priceStars = priceStars,
             rtpExtMin = 0.4,
             rtpExtMax = 0.5,
             jackpotAlpha = 0.02,
-            items = listOf(PrizeItemConfig(id = "item-1", type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
+            items = listOf(PrizeItemConfig(id = prizeId, type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
         )
-        val planSlot = slot<AwardPlan>()
-        coEvery { awardService.schedule(capture(planSlot)) } returns Unit
-        every { casesRepository.get(case.id) } returns case
-        val payload = PaymentPayload(caseId = case.id, userId = 777, nonce = "nonce", ts = 1L)
-        val drawRecord =
+
+    private fun rngResult(
+        payload: PaymentPayload,
+        resultItemId: String?,
+        ppm: Int,
+    ): RngDrawResult {
+        val record =
             RngDrawRecord(
-                caseId = case.id,
+                caseId = payload.caseId,
                 userId = payload.userId,
                 nonce = payload.nonce,
                 serverSeedHash = "hash",
                 rollHex = "abcdef",
-                ppm = 123,
-                resultItemId = "item-1",
+                ppm = ppm,
+                resultItemId = resultItemId,
                 createdAt = Instant.parse("2024-01-01T00:00:00Z"),
             )
         val receipt =
@@ -96,198 +222,48 @@ class SuccessfulPaymentHandlerTest {
                 serverSeedHash = "hash",
                 clientSeed = "client-seed",
                 rollHex = "abcdef",
-                ppm = 123,
+                ppm = ppm,
             )
-        every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
+        return RngDrawResult(record, receipt)
+    }
+
+    private fun stubCase(case: CaseConfig) {
+        every { casesRepository.get(case.id) } returns case
+    }
+
+    private fun stubDraw(
+        payload: PaymentPayload,
+        result: RngDrawResult,
+    ) {
+        every { rngService.draw(payload.caseId, payload.userId, payload.nonce) } returns result
+    }
+
+    private fun stubSendMessage(chatId: Long) {
         coEvery {
             telegramApiClient.sendMessage(
-                chatId = payload.userId,
+                chatId = chatId,
                 text = any(),
                 disableNotification = true,
                 replyToMessageId = any(),
             )
-        } returns messageStub(chatId = payload.userId)
-
-        val message = successfulPaymentMessage(
-            chargeId = "charge-1",
-            payload = payload.encode(),
-            userId = payload.userId,
-            totalAmount = case.priceStars,
-            currency = STARS_CURRENCY_CODE,
-        )
-
-        val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
-        val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
-        val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
-        handler.handle(updateId = 1L, message = message)
-
-        val capturedPlan = planSlot.captured
-        assertNotNull(capturedPlan)
-        assertEquals("charge-1", capturedPlan.telegramPaymentChargeId)
-        assertEquals(case.id, capturedPlan.caseId)
-        assertEquals(payload.userId, capturedPlan.userId)
-        assertEquals(payload.nonce, capturedPlan.nonce)
-        assertEquals(case.priceStars, capturedPlan.totalAmount)
-        assertEquals(STARS_CURRENCY_CODE, capturedPlan.currency)
-        assertEquals(drawRecord, capturedPlan.rngRecord)
-        assertEquals(receipt, capturedPlan.rngReceipt)
-        assertEquals("item-1", capturedPlan.resultItemId)
-
-        assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
-        assertEquals(idempotentBefore, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
-        assertEquals(failBefore, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
-
-        coVerify(exactly = 1) { awardService.schedule(any()) }
-        coVerify(exactly = 1) { telegramApiClient.sendMessage(payload.userId, any(), true, message.message_id) }
+        } returns messageStub(chatId)
     }
 
-    @Test
-    fun `duplicate payment is idempotent`() = runTest {
-        val case = CaseConfig(
-            id = "case-2",
-            title = "Case 2",
-            priceStars = 200,
-            rtpExtMin = 0.4,
-            rtpExtMax = 0.5,
-            jackpotAlpha = 0.02,
-            items = listOf(PrizeItemConfig(id = "item-2", type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
-        )
-        coEvery { awardService.schedule(any()) } returns Unit
-        every { casesRepository.get(case.id) } returns case
-        val payload = PaymentPayload(caseId = case.id, userId = 900, nonce = "nonce", ts = 1L)
-        val drawRecord =
-            RngDrawRecord(
-                caseId = case.id,
-                userId = payload.userId,
-                nonce = payload.nonce,
-                serverSeedHash = "hash",
-                rollHex = "abcdef",
-                ppm = 456,
-                resultItemId = "item-2",
-                createdAt = Instant.parse("2024-01-01T00:00:00Z"),
-            )
-        val receipt =
-            RngReceipt(
-                date = LocalDate.parse("2024-01-02"),
-                serverSeedHash = "hash",
-                clientSeed = "seed",
-                rollHex = "abcdef",
-                ppm = 456,
-            )
-        every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
-        coEvery {
-            telegramApiClient.sendMessage(payload.userId, any(), true, any())
-        } returns messageStub(chatId = payload.userId)
-
-        val message = successfulPaymentMessage(
-            chargeId = "charge-dup",
-            payload = payload.encode(),
-            userId = payload.userId,
-            totalAmount = case.priceStars,
-            currency = STARS_CURRENCY_CODE,
-        )
-
-        val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
-        val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
-        val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
-        handler.handle(updateId = 100L, message = message)
-        handler.handle(updateId = 101L, message = message)
-
-        assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
-        assertEquals(idempotentBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
-        assertEquals(failBefore, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
-
-        coVerify(exactly = 1) { awardService.schedule(any()) }
-        coVerify(exactly = 1) { telegramApiClient.sendMessage(payload.userId, any(), true, message.message_id) }
-    }
-
-    @Test
-    fun `validation failure is retriable`() = runTest {
-        val case = CaseConfig(
-            id = "case-3",
-            title = "Case 3",
-            priceStars = 300,
-            rtpExtMin = 0.4,
-            rtpExtMax = 0.5,
-            jackpotAlpha = 0.02,
-            items = listOf(PrizeItemConfig(id = "item-3", type = CaseSlotType.GIFT, probabilityPpm = 1_000_000)),
-        )
-        every { casesRepository.get(case.id) } returns case
-        coEvery { awardService.schedule(any()) } returns Unit
-        val payload = PaymentPayload(caseId = case.id, userId = 42, nonce = "nonce", ts = 1L)
-        val drawRecord =
-            RngDrawRecord(
-                caseId = case.id,
-                userId = payload.userId,
-                nonce = payload.nonce,
-                serverSeedHash = "hash",
-                rollHex = "abc123",
-                ppm = 789,
-                resultItemId = null,
-                createdAt = Instant.parse("2024-01-03T00:00:00Z"),
-            )
-        val receipt =
-            RngReceipt(
-                date = LocalDate.parse("2024-01-03"),
-                serverSeedHash = "hash",
-                clientSeed = "seed",
-                rollHex = "abc123",
-                ppm = 789,
-            )
-        every { rngService.draw(case.id, payload.userId, payload.nonce) } returns RngDrawResult(drawRecord, receipt)
-        coEvery { telegramApiClient.sendMessage(payload.userId, any(), true, any()) } returns messageStub(chatId = payload.userId)
-
-        val invalidMessage = successfulPaymentMessage(
-            chargeId = "charge-retry",
-            payload = payload.encode(),
-            userId = payload.userId,
-            totalAmount = case.priceStars,
-            currency = "USD",
-        )
-        val successBefore = metricCount(MetricsNames.PAY_SUCCESS_TOTAL)
-        val idempotentBefore = metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL)
-        val failBefore = metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL)
-        handler.handle(updateId = 200L, message = invalidMessage)
-
-        assertEquals(successBefore, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
-        assertEquals(idempotentBefore, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
-        assertEquals(failBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
-        coVerify(exactly = 0) { awardService.schedule(any()) }
-
-        val validMessage = successfulPaymentMessage(
-            chargeId = "charge-retry",
-            payload = payload.encode(),
-            userId = payload.userId,
-            totalAmount = case.priceStars,
-            currency = STARS_CURRENCY_CODE,
-        )
-        handler.handle(updateId = 201L, message = validMessage)
-
-        assertEquals(successBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
-        assertEquals(idempotentBefore, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
-        assertEquals(failBefore + 1.0, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
-        coVerify(exactly = 1) { awardService.schedule(any()) }
-    }
-
-    private fun metricCount(name: String): Double =
-        Metrics.counter(meterRegistry, name, MetricsTags.COMPONENT to "payments").count()
-
-    private fun successfulPaymentMessage(
+    private fun paymentMessage(
         chargeId: String,
-        payload: String,
-        userId: Long,
+        payload: PaymentPayload,
         totalAmount: Long,
         currency: String,
     ): MessageDto =
         MessageDto(
             message_id = 1,
             date = 0,
-            chat = ChatDto(id = userId, type = "private"),
+            chat = ChatDto(id = payload.userId, type = "private"),
             successful_payment =
                 SuccessfulPaymentDto(
                     currency = currency,
                     total_amount = totalAmount,
-                    invoice_payload = payload,
+                    invoice_payload = payload.encode(),
                     telegram_payment_charge_id = chargeId,
                     provider_payment_charge_id = "provider",
                 ),
@@ -300,4 +276,37 @@ class SuccessfulPaymentHandlerTest {
             chat = ChatDto(id = chatId, type = "private"),
         )
 
+    private fun assertPlanMatches(
+        plan: AwardPlan,
+        payload: PaymentPayload,
+        totalAmount: Long,
+        drawResult: RngDrawResult,
+        chargeId: String,
+    ) {
+        assertEquals(chargeId, plan.telegramPaymentChargeId)
+        assertEquals(payload.caseId, plan.caseId)
+        assertEquals(payload.userId, plan.userId)
+        assertEquals(payload.nonce, plan.nonce)
+        assertEquals(totalAmount, plan.totalAmount)
+        assertEquals(STARS_CURRENCY_CODE, plan.currency)
+        assertEquals(drawResult.record, plan.rngRecord)
+        assertEquals(drawResult.receipt, plan.rngReceipt)
+        assertEquals(drawResult.record.resultItemId, plan.resultItemId)
+    }
+
+    private data class MetricsSnapshot(
+        val success: Double,
+        val idempotent: Double,
+        val failure: Double,
+    )
+
+    private fun MetricsSnapshot.assertDelta(
+        success: Double,
+        idempotent: Double,
+        failure: Double,
+    ) {
+        assertEquals(this.success + success, metricCount(MetricsNames.PAY_SUCCESS_TOTAL))
+        assertEquals(this.idempotent + idempotent, metricCount(MetricsNames.PAY_SUCCESS_IDEMPOTENT_TOTAL))
+        assertEquals(this.failure + failure, metricCount(MetricsNames.PAY_SUCCESS_FAIL_TOTAL))
+    }
 }

--- a/src/test/kotlin/com/example/app/telegram/UpdateDispatcherTest.kt
+++ b/src/test/kotlin/com/example/app/telegram/UpdateDispatcherTest.kt
@@ -27,7 +27,7 @@ class UpdateDispatcherTest {
                 UpdateDispatcher(
                     scope = this,
                     meterRegistry = meterRegistry,
-                    queueCapacity = 4,
+                    settings = UpdateDispatcherSettings(queueCapacity = 4),
                 )
 
             try {
@@ -55,7 +55,7 @@ class UpdateDispatcherTest {
                 UpdateDispatcher(
                     scope = this,
                     meterRegistry = meterRegistry,
-                    queueCapacity = 4,
+                    settings = UpdateDispatcherSettings(queueCapacity = 4),
                 )
 
             try {
@@ -85,7 +85,7 @@ class UpdateDispatcherTest {
                 UpdateDispatcher(
                     scope = this,
                     meterRegistry = meterRegistry,
-                    queueCapacity = 2,
+                    settings = UpdateDispatcherSettings(queueCapacity = 2),
                 )
 
             try {
@@ -116,8 +116,7 @@ class UpdateDispatcherTest {
                 UpdateDispatcher(
                     scope = scope,
                     meterRegistry = meterRegistry,
-                    queueCapacity = 4,
-                    workers = 2,
+                    settings = UpdateDispatcherSettings(queueCapacity = 4, workers = 2),
                 )
 
             val dropBeforeStart = meterRegistry.queueCounter(MetricsNames.UPDATES_DROPPED_TOTAL)


### PR DESCRIPTION
## Summary
- refactor successful payment handling with explicit validation, refund outcomes, and logging helpers
- harden award delivery with resilient runCatching flows and reusable gift selection helper
- streamline telegram integration setup, dispatcher lifecycle management, and gift catalog caching
- refresh associated tests to align with the new helpers and metrics snapshots

## Testing
- `./gradlew clean build test detekt ktlintCheck --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d75beef5708321ac4655aa9090d323