### PR TITLE
Integrate mini app invoice flow

### DIFF
--- a/miniapp/src/lib/pay.ts
+++ b/miniapp/src/lib/pay.ts
@@ -18,6 +18,15 @@ export const openInvoice = async (invoiceLink: string): Promise<InvoiceStatus> =
       resolve(status);
     };
 
+    const handleInvoiceStatus = (status: unknown) => {
+      if (status === 'paid' || status === 'cancelled' || status === 'failed') {
+        resolveOnce(status);
+        return;
+      }
+
+      resolveOnce('failed');
+    };
+
     const handleReject = (reason: unknown) => {
       if (settled) {
         return;
@@ -31,7 +40,7 @@ export const openInvoice = async (invoiceLink: string): Promise<InvoiceStatus> =
     };
 
     try {
-      const openResult = webApp.openInvoice(invoiceLink, resolveOnce);
+      const openResult = webApp.openInvoice(invoiceLink, handleInvoiceStatus);
       Promise.resolve(openResult)
         .then((opened) => {
           if (opened === false) {


### PR DESCRIPTION
## Summary
- generate base62 nonces for mini app invoices and expose the invoice link payload endpoint
- normalize Telegram WebApp.openInvoice handling and surfacing invoice statuses in the mini app UI

## Testing
- ./gradlew clean build test detekt ktlintCheck --console=plain
- npm -C miniapp run build

------
https://chatgpt.com/codex/tasks/task_e_68d88797fee083218987a19779a741f5