### PR TITLE
Add RateLimitPlugin with IP/subject token buckets and bootstrap

### DIFF
--- a/src/main/kotlin/com/example/giftsbot/antifraud/AntifraudBootstrap.kt
+++ b/src/main/kotlin/com/example/giftsbot/antifraud/AntifraudBootstrap.kt
@@ -1,0 +1,141 @@
+package com.example.giftsbot.antifraud
+
+import com.example.giftsbot.antifraud.store.InMemoryBucketStore
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.micrometer.core.instrument.MeterRegistry
+
+private const val CONFIG_PREFIX = "app.antifraud"
+private const val CONFIG_IP_ENABLED = "$CONFIG_PREFIX.rl.ip.enabled"
+private const val CONFIG_IP_RPS = "$CONFIG_PREFIX.rl.ip.rps"
+private const val CONFIG_IP_BURST = "$CONFIG_PREFIX.rl.ip.capacity"
+private const val CONFIG_IP_TTL = "$CONFIG_PREFIX.rl.ip.ttlSeconds"
+private const val CONFIG_SUBJECT_ENABLED = "$CONFIG_PREFIX.rl.subject.enabled"
+private const val CONFIG_SUBJECT_RPS = "$CONFIG_PREFIX.rl.subject.rps"
+private const val CONFIG_SUBJECT_BURST = "$CONFIG_PREFIX.rl.subject.capacity"
+private const val CONFIG_SUBJECT_TTL = "$CONFIG_PREFIX.rl.subject.ttlSeconds"
+private const val CONFIG_TRUST_PROXY = "$CONFIG_PREFIX.rl.trustProxy"
+private const val CONFIG_INCLUDE_PATHS = "$CONFIG_PREFIX.rl.includePaths"
+private const val CONFIG_EXCLUDE_PATHS = "$CONFIG_PREFIX.rl.excludePaths"
+private const val CONFIG_RETRY_AFTER = "$CONFIG_PREFIX.rl.retryAfter"
+
+private const val ENV_IP_ENABLED = "RL_IP_ENABLED"
+private const val ENV_IP_RPS = "RL_IP_RPS"
+private const val ENV_IP_BURST = "RL_IP_BURST"
+private const val ENV_IP_TTL = "RL_IP_TTL_SECONDS"
+private const val ENV_SUBJECT_ENABLED = "RL_SUBJECT_ENABLED"
+private const val ENV_SUBJECT_RPS = "RL_SUBJECT_RPS"
+private const val ENV_SUBJECT_BURST = "RL_SUBJECT_BURST"
+private const val ENV_SUBJECT_TTL = "RL_SUBJECT_TTL_SECONDS"
+private const val ENV_TRUST_PROXY = "RL_TRUST_PROXY"
+private const val ENV_INCLUDE_PATHS = "RL_INCLUDE_PATHS"
+private const val ENV_EXCLUDE_PATHS = "RL_EXCLUDE_PATHS"
+private const val ENV_RETRY_AFTER = "RL_RETRY_AFTER_SECONDS"
+
+fun Application.installAntifraudIntegration(
+    meterRegistry: MeterRegistry,
+    store: BucketStore? = null,
+    clock: Clock = SystemClock,
+    subjectResolver: ((ApplicationCall) -> Long?)? = null,
+) {
+    val rateLimitConfig = loadConfig()
+    val bucketStore = store ?: InMemoryBucketStore()
+    val sharedTokenBucket = TokenBucket(bucketStore, clock)
+    install(RateLimitPlugin) {
+        tokenBucket = sharedTokenBucket
+        this.clock = clock
+        this.meterRegistry = meterRegistry
+        config = rateLimitConfig
+        subjectResolver?.let { resolver -> this.subjectResolver = resolver }
+    }
+    environment.log.info(
+        "Antifraud installed (ip=${if (rateLimitConfig.ipEnabled) "on" else "off"}, " +
+            "subject=${if (rateLimitConfig.subjectEnabled) "on" else "off"}, " +
+            "trustProxy=${if (rateLimitConfig.trustProxy) "on" else "off"})",
+    )
+}
+
+private fun Application.loadConfig(): RateLimitConfig {
+    val ipEnabled = readBoolean(ENV_IP_ENABLED, CONFIG_IP_ENABLED, default = true)
+    val ipRps = readDouble(ENV_IP_RPS, CONFIG_IP_RPS, default = 100.0)
+    val ipBurst = readInt(ENV_IP_BURST, CONFIG_IP_BURST, default = 20).coerceAtLeast(1)
+    val ipTtl = readLong(ENV_IP_TTL, CONFIG_IP_TTL, default = 600L).coerceAtLeast(1L)
+    val subjectEnabled = readBoolean(ENV_SUBJECT_ENABLED, CONFIG_SUBJECT_ENABLED, default = true)
+    val subjectRps = readDouble(ENV_SUBJECT_RPS, CONFIG_SUBJECT_RPS, default = 60.0)
+    val subjectBurst = readInt(ENV_SUBJECT_BURST, CONFIG_SUBJECT_BURST, default = 20).coerceAtLeast(1)
+    val subjectTtl = readLong(ENV_SUBJECT_TTL, CONFIG_SUBJECT_TTL, default = 600L).coerceAtLeast(1L)
+    val trustProxy = readBoolean(ENV_TRUST_PROXY, CONFIG_TRUST_PROXY, default = false)
+    val includePaths =
+        readString(ENV_INCLUDE_PATHS, CONFIG_INCLUDE_PATHS, default = "/telegram/webhook,/api/miniapp/invoice")
+            .split(',')
+            .mapNotNull { part -> part.trim().takeIf { it.isNotEmpty() } }
+    val excludePaths =
+        readString(ENV_EXCLUDE_PATHS, CONFIG_EXCLUDE_PATHS, default = "")
+            .split(',')
+            .mapNotNull { part -> part.trim().takeIf { it.isNotEmpty() } }
+    val retryAfter = readLong(ENV_RETRY_AFTER, CONFIG_RETRY_AFTER, default = 60L).coerceAtLeast(0L)
+    return RateLimitConfig(
+        ipEnabled = ipEnabled,
+        ipCapacity = ipBurst,
+        ipRefillPerSec = ipRps,
+        ipTtlSeconds = ipTtl,
+        subjectEnabled = subjectEnabled,
+        subjectCapacity = subjectBurst,
+        subjectRefillPerSec = subjectRps,
+        subjectTtlSeconds = subjectTtl,
+        trustProxy = trustProxy,
+        includePaths = includePaths,
+        excludePaths = excludePaths,
+        retryAfterFallbackSeconds = retryAfter,
+    )
+}
+
+private fun Application.readString(
+    envKey: String,
+    configKey: String,
+    default: String,
+): String = readRaw(envKey, configKey) ?: default
+
+private fun Application.readBoolean(
+    envKey: String,
+    configKey: String,
+    default: Boolean,
+): Boolean {
+    val raw = readRaw(envKey, configKey) ?: return default
+    return when (raw.lowercase()) {
+        "true", "1", "yes", "on" -> true
+        "false", "0", "no", "off" -> false
+        else -> default
+    }
+}
+
+private fun Application.readInt(
+    envKey: String,
+    configKey: String,
+    default: Int,
+): Int = readRaw(envKey, configKey)?.toIntOrNull()?.takeIf { it > 0 } ?: default
+
+private fun Application.readLong(
+    envKey: String,
+    configKey: String,
+    default: Long,
+): Long = readRaw(envKey, configKey)?.toLongOrNull()?.takeIf { it > 0 } ?: default
+
+private fun Application.readDouble(
+    envKey: String,
+    configKey: String,
+    default: Double,
+): Double = readRaw(envKey, configKey)?.toDoubleOrNull()?.takeIf { it >= 0.0 } ?: default
+
+private fun Application.readRaw(
+    envKey: String,
+    configKey: String,
+): String? {
+    val envValue = System.getenv(envKey)?.takeUnless { it.isBlank() }
+    if (envValue != null) {
+        return envValue
+    }
+    val configEntry = environment.config.propertyOrNull(configKey)
+    return configEntry?.getString()?.takeUnless { it.isBlank() }
+}

--- a/src/main/kotlin/com/example/giftsbot/antifraud/IpAndSubjectExtractors.kt
+++ b/src/main/kotlin/com/example/giftsbot/antifraud/IpAndSubjectExtractors.kt
@@ -1,0 +1,35 @@
+package com.example.giftsbot.antifraud
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.origin
+import io.ktor.server.request.header
+import io.ktor.util.AttributeKey
+
+private val subjectIdAttribute = AttributeKey<Long>("subject.id")
+
+fun extractClientIp(
+    call: ApplicationCall,
+    trustProxy: Boolean,
+): String {
+    if (trustProxy) {
+        val forwardedHeader = call.request.header("X-Forwarded-For")
+        val forwardedIp =
+            forwardedHeader
+                ?.split(',')
+                ?.firstOrNull()
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        if (forwardedIp != null) {
+            return forwardedIp
+        }
+    }
+    return call.request.origin.remoteHost
+}
+
+fun extractSubjectId(call: ApplicationCall): Long? {
+    if (call.attributes.contains(subjectIdAttribute)) {
+        return call.attributes[subjectIdAttribute]
+    }
+    val headerValue = call.request.header("X-Subject-Id")?.trim()
+    return headerValue?.takeIf { it.isNotEmpty() }?.toLongOrNull()
+}

--- a/src/main/kotlin/com/example/giftsbot/antifraud/RateLimitPlugin.kt
+++ b/src/main/kotlin/com/example/giftsbot/antifraud/RateLimitPlugin.kt
@@ -1,0 +1,256 @@
+package com.example.giftsbot.antifraud
+
+import com.example.giftsbot.antifraud.RateLimitType.IP
+import com.example.giftsbot.antifraud.RateLimitType.SUBJECT
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.path
+import io.ktor.server.response.respond
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.serialization.Serializable
+
+const val RATE_LIMIT_PLUGIN_NAME: String = "RateLimitPlugin"
+
+data class RateLimitConfig(
+    val ipEnabled: Boolean,
+    val ipCapacity: Int,
+    val ipRefillPerSec: Double,
+    val ipTtlSeconds: Long,
+    val subjectEnabled: Boolean,
+    val subjectCapacity: Int,
+    val subjectRefillPerSec: Double,
+    val subjectTtlSeconds: Long,
+    val trustProxy: Boolean,
+    val includePaths: List<String>,
+    val excludePaths: List<String>,
+    val retryAfterFallbackSeconds: Long,
+)
+
+class RateLimitPluginConfig {
+    lateinit var tokenBucket: TokenBucket
+    lateinit var clock: Clock
+    lateinit var meterRegistry: MeterRegistry
+    lateinit var config: RateLimitConfig
+    var subjectResolver: (ApplicationCall) -> Long? = ::extractSubjectId
+
+    internal fun validated(): RateLimitPluginDependencies {
+        check(::tokenBucket.isInitialized) { "RateLimitPlugin tokenBucket is not initialized" }
+        check(::clock.isInitialized) { "RateLimitPlugin clock is not initialized" }
+        check(::meterRegistry.isInitialized) { "RateLimitPlugin meterRegistry is not initialized" }
+        check(::config.isInitialized) { "RateLimitPlugin config is not initialized" }
+        return RateLimitPluginDependencies(
+            tokenBucket = tokenBucket,
+            clock = clock,
+            meterRegistry = meterRegistry,
+            config = config,
+            subjectResolver = subjectResolver,
+        )
+    }
+}
+
+internal data class RateLimitPluginDependencies(
+    val tokenBucket: TokenBucket,
+    val clock: Clock,
+    val meterRegistry: MeterRegistry,
+    val config: RateLimitConfig,
+    val subjectResolver: (ApplicationCall) -> Long?,
+)
+
+private enum class RateLimitType(
+    val metricTag: String,
+) {
+    IP("ip"),
+    SUBJECT("subject"),
+}
+
+private const val ERROR_CODE: String = "rate_limited"
+
+val RateLimitPlugin =
+    createApplicationPlugin(
+        name = RATE_LIMIT_PLUGIN_NAME,
+        createConfiguration = ::RateLimitPluginConfig,
+    ) {
+        val dependencies = pluginConfig.validated()
+        val ipParams =
+            BucketParams(
+                capacity = dependencies.config.ipCapacity,
+                refillTokensPerSecond = dependencies.config.ipRefillPerSec,
+                ttlSeconds = dependencies.config.ipTtlSeconds,
+            )
+        val subjectParams =
+            BucketParams(
+                capacity = dependencies.config.subjectCapacity,
+                refillTokensPerSecond = dependencies.config.subjectRefillPerSec,
+                ttlSeconds = dependencies.config.subjectTtlSeconds,
+            )
+        val metrics = RateLimitMetrics(dependencies.meterRegistry)
+        val includePaths = normalizePrefixes(dependencies.config.includePaths)
+        val excludePaths = normalizePrefixes(dependencies.config.excludePaths)
+
+        onCall { call ->
+            if (!pathMatches(call.request.path(), includePaths, excludePaths)) {
+                return@onCall
+            }
+            metrics.incrementChecked()
+
+            if (dependencies.config.ipEnabled) {
+                val ip = extractClientIp(call, dependencies.config.trustProxy)
+                val decision =
+                    dependencies
+                        .tokenBucket
+                        .tryConsume(IpKey(ip), ipParams)
+                        .withFallback(
+                            params = ipParams,
+                            fallbackSeconds = dependencies.config.retryAfterFallbackSeconds,
+                            nowMillis = dependencies.clock.nowMillis(),
+                        )
+                if (!decision.allowed) {
+                    val retryAfter = decision.retryAfterSeconds ?: dependencies.config.retryAfterFallbackSeconds
+                    metrics.recordBlocked(IP, retryAfter)
+                    call.respondRateLimited(IP.metricTag, retryAfter)
+                    return@onCall
+                }
+                metrics.recordAllowed(IP)
+            }
+
+            if (dependencies.config.subjectEnabled) {
+                val subjectId = dependencies.subjectResolver(call)
+                if (subjectId != null) {
+                    val decision =
+                        dependencies
+                            .tokenBucket
+                            .tryConsume(SubjectKey(subjectId), subjectParams)
+                            .withFallback(
+                                params = subjectParams,
+                                fallbackSeconds = dependencies.config.retryAfterFallbackSeconds,
+                                nowMillis = dependencies.clock.nowMillis(),
+                            )
+                    if (!decision.allowed) {
+                        val retryAfter = decision.retryAfterSeconds ?: dependencies.config.retryAfterFallbackSeconds
+                        metrics.recordBlocked(SUBJECT, retryAfter)
+                        call.respondRateLimited(SUBJECT.metricTag, retryAfter)
+                        return@onCall
+                    }
+                    metrics.recordAllowed(SUBJECT)
+                }
+            }
+        }
+    }
+
+private fun normalizePrefixes(prefixes: List<String>): List<String> =
+    prefixes.mapNotNull { prefix -> prefix.trim().takeIf { it.isNotEmpty() } }
+
+private fun pathMatches(
+    path: String,
+    includes: List<String>,
+    excludes: List<String>,
+): Boolean {
+    val included = includes.isEmpty() || includes.any { include -> path.startsWith(include) }
+    if (!included) {
+        return false
+    }
+    val excluded = excludes.any { exclude -> path.startsWith(exclude) }
+    return !excluded
+}
+
+private fun RateLimitDecision.withFallback(
+    params: BucketParams,
+    fallbackSeconds: Long,
+    nowMillis: Long,
+): RateLimitDecision {
+    if (allowed) {
+        return this
+    }
+    val effectiveRetryAfter = retryAfterSeconds ?: fallbackSeconds
+    return if (params.refillTokensPerSecond > 0.0) {
+        if (effectiveRetryAfter == retryAfterSeconds) {
+            this
+        } else {
+            copy(retryAfterSeconds = effectiveRetryAfter)
+        }
+    } else {
+        val safeFallback = fallbackSeconds.coerceAtLeast(0L)
+        copy(
+            retryAfterSeconds = safeFallback,
+            resetAtMillis = nowMillis + safeFallback * 1000L,
+        )
+    }
+}
+
+private suspend fun ApplicationCall.respondRateLimited(
+    type: String,
+    retryAfterSeconds: Long,
+) {
+    val safeRetryAfter = retryAfterSeconds.coerceAtLeast(0L)
+    response.headers.append(HttpHeaders.RetryAfter, safeRetryAfter.toString())
+    val payload =
+        RateLimitErrorResponse(
+            error = ERROR_CODE,
+            status = HttpStatusCode.TooManyRequests.value,
+            requestId = callId ?: "",
+            type = type,
+            retryAfterSeconds = safeRetryAfter,
+        )
+    respond(HttpStatusCode.TooManyRequests, payload)
+}
+
+private class RateLimitMetrics(
+    registry: MeterRegistry,
+) {
+    private val blockedIp: Counter = counter(registry, "af_rl_blocked_total", IP.metricTag)
+    private val blockedSubject: Counter = counter(registry, "af_rl_blocked_total", SUBJECT.metricTag)
+    private val allowedIp: Counter = counter(registry, "af_rl_allowed_total", IP.metricTag)
+    private val allowedSubject: Counter = counter(registry, "af_rl_allowed_total", SUBJECT.metricTag)
+    private val checked: Counter = Counter.builder("af_rl_checked_total").register(registry)
+    private val retryAfterSummary: DistributionSummary =
+        DistributionSummary
+            .builder("af_rl_retry_after_seconds")
+            .register(registry)
+
+    fun incrementChecked() {
+        checked.increment()
+    }
+
+    fun recordAllowed(type: RateLimitType) {
+        when (type) {
+            IP -> allowedIp.increment()
+            SUBJECT -> allowedSubject.increment()
+        }
+    }
+
+    fun recordBlocked(
+        type: RateLimitType,
+        retryAfterSeconds: Long,
+    ) {
+        val retryValue = retryAfterSeconds.coerceAtLeast(0L).toDouble()
+        when (type) {
+            IP -> blockedIp.increment()
+            SUBJECT -> blockedSubject.increment()
+        }
+        retryAfterSummary.record(retryValue)
+    }
+
+    private fun counter(
+        registry: MeterRegistry,
+        name: String,
+        type: String,
+    ): Counter =
+        Counter
+            .builder(name)
+            .tag("type", type)
+            .register(registry)
+}
+
+@Serializable
+private data class RateLimitErrorResponse(
+    val error: String,
+    val status: Int,
+    val requestId: String,
+    val type: String,
+    val retryAfterSeconds: Long,
+)

--- a/src/test/kotlin/com/example/giftsbot/antifraud/RateLimitPluginTest.kt
+++ b/src/test/kotlin/com/example/giftsbot/antifraud/RateLimitPluginTest.kt
@@ -1,0 +1,281 @@
+package com.example.giftsbot.antifraud
+
+import com.example.giftsbot.antifraud.store.InMemoryBucketStore
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+private const val CONFIG_INCLUDE_PATHS = "app.antifraud.rl.includePaths"
+private const val CONFIG_EXCLUDE_PATHS = "app.antifraud.rl.excludePaths"
+private const val CONFIG_TRUST_PROXY = "app.antifraud.rl.trustProxy"
+private const val CONFIG_RETRY_AFTER = "app.antifraud.rl.retryAfter"
+private const val CONFIG_IP_ENABLED = "app.antifraud.rl.ip.enabled"
+private const val CONFIG_IP_BURST = "app.antifraud.rl.ip.capacity"
+private const val CONFIG_IP_RPS = "app.antifraud.rl.ip.rps"
+private const val CONFIG_IP_TTL = "app.antifraud.rl.ip.ttlSeconds"
+private const val CONFIG_SUBJECT_ENABLED = "app.antifraud.rl.subject.enabled"
+private const val CONFIG_SUBJECT_BURST = "app.antifraud.rl.subject.capacity"
+private const val CONFIG_SUBJECT_RPS = "app.antifraud.rl.subject.rps"
+private const val CONFIG_SUBJECT_TTL = "app.antifraud.rl.subject.ttlSeconds"
+
+class RateLimitPluginTest {
+    private val json = Json { ignoreUnknownKeys = false }
+
+    @Test
+    fun `ip limit blocks second request`() {
+        testApplication {
+            val clock = TestClock()
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val store = InMemoryBucketStore()
+            configureEnvironment {
+                put(CONFIG_INCLUDE_PATHS, "/test")
+                put(CONFIG_EXCLUDE_PATHS, "")
+                put(CONFIG_TRUST_PROXY, "true")
+                put(CONFIG_RETRY_AFTER, "42")
+                put(CONFIG_IP_ENABLED, "true")
+                put(CONFIG_IP_BURST, "1")
+                put(CONFIG_IP_RPS, "0")
+                put(CONFIG_IP_TTL, "60")
+                put(CONFIG_SUBJECT_ENABLED, "false")
+                put(CONFIG_SUBJECT_BURST, "1")
+                put(CONFIG_SUBJECT_RPS, "0")
+                put(CONFIG_SUBJECT_TTL, "60")
+            }
+            configureApplication(meterRegistry, store, clock)
+
+            val okResponse =
+                client.get("/test") {
+                    header("X-Forwarded-For", "203.0.113.1")
+                }
+            assertEquals(HttpStatusCode.OK, okResponse.status)
+
+            val blockedResponse =
+                client.get("/test") {
+                    header("X-Forwarded-For", "203.0.113.1")
+                }
+            assertEquals(HttpStatusCode.TooManyRequests, blockedResponse.status)
+            assertEquals("42", blockedResponse.headers[HttpHeaders.RetryAfter])
+            val payload = json.decodeFromString<RateLimitError>(blockedResponse.bodyAsText())
+            assertEquals("rate_limited", payload.error)
+            assertEquals(429, payload.status)
+            assertEquals("ip", payload.type)
+            assertEquals(42, payload.retryAfterSeconds)
+        }
+    }
+
+    @Test
+    fun `subject limit blocks when subject exceeds tokens`() {
+        testApplication {
+            val clock = TestClock()
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val store = InMemoryBucketStore()
+            configureEnvironment {
+                put(CONFIG_INCLUDE_PATHS, "/test")
+                put(CONFIG_EXCLUDE_PATHS, "")
+                put(CONFIG_TRUST_PROXY, "false")
+                put(CONFIG_RETRY_AFTER, "30")
+                put(CONFIG_IP_ENABLED, "true")
+                put(CONFIG_IP_BURST, "5")
+                put(CONFIG_IP_RPS, "5")
+                put(CONFIG_IP_TTL, "60")
+                put(CONFIG_SUBJECT_ENABLED, "true")
+                put(CONFIG_SUBJECT_BURST, "1")
+                put(CONFIG_SUBJECT_RPS, "0")
+                put(CONFIG_SUBJECT_TTL, "60")
+            }
+            configureApplication(meterRegistry, store, clock)
+
+            val okResponse =
+                client.get("/test") {
+                    header("X-Subject-Id", "777")
+                }
+            assertEquals(HttpStatusCode.OK, okResponse.status)
+
+            val blockedResponse =
+                client.get("/test") {
+                    header("X-Subject-Id", "777")
+                }
+            assertEquals(HttpStatusCode.TooManyRequests, blockedResponse.status)
+            val payload = json.decodeFromString<RateLimitError>(blockedResponse.bodyAsText())
+            assertEquals("subject", payload.type)
+            assertEquals(30, payload.retryAfterSeconds)
+        }
+    }
+
+    @Test
+    fun `excluded path bypasses rate limiting`() {
+        testApplication {
+            val clock = TestClock()
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val store = InMemoryBucketStore()
+            configureEnvironment {
+                put(CONFIG_INCLUDE_PATHS, "/test")
+                put(CONFIG_EXCLUDE_PATHS, "/test/excluded")
+                put(CONFIG_TRUST_PROXY, "true")
+                put(CONFIG_RETRY_AFTER, "60")
+                put(CONFIG_IP_ENABLED, "true")
+                put(CONFIG_IP_BURST, "1")
+                put(CONFIG_IP_RPS, "0")
+                put(CONFIG_IP_TTL, "60")
+                put(CONFIG_SUBJECT_ENABLED, "true")
+                put(CONFIG_SUBJECT_BURST, "1")
+                put(CONFIG_SUBJECT_RPS, "0")
+                put(CONFIG_SUBJECT_TTL, "60")
+            }
+            configureApplication(meterRegistry, store, clock)
+
+            repeat(3) {
+                val response =
+                    client.get("/test/excluded") {
+                        header("X-Forwarded-For", "198.51.100.1")
+                        header("X-Subject-Id", "100")
+                    }
+                assertEquals(HttpStatusCode.OK, response.status)
+            }
+        }
+    }
+
+    @Test
+    fun `both buckets enforce limits independently`() {
+        testApplication {
+            val clock = TestClock()
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val store = InMemoryBucketStore()
+            configureEnvironment {
+                put(CONFIG_INCLUDE_PATHS, "/test")
+                put(CONFIG_EXCLUDE_PATHS, "")
+                put(CONFIG_TRUST_PROXY, "true")
+                put(CONFIG_RETRY_AFTER, "15")
+                put(CONFIG_IP_ENABLED, "true")
+                put(CONFIG_IP_BURST, "5")
+                put(CONFIG_IP_RPS, "0")
+                put(CONFIG_IP_TTL, "60")
+                put(CONFIG_SUBJECT_ENABLED, "true")
+                put(CONFIG_SUBJECT_BURST, "1")
+                put(CONFIG_SUBJECT_RPS, "0")
+                put(CONFIG_SUBJECT_TTL, "60")
+            }
+            configureApplication(meterRegistry, store, clock)
+
+            val okResponse =
+                client.get("/test") {
+                    header("X-Forwarded-For", "192.0.2.10")
+                    header("X-Subject-Id", "55")
+                }
+            assertEquals(HttpStatusCode.OK, okResponse.status)
+
+            val blockedResponse =
+                client.get("/test") {
+                    header("X-Forwarded-For", "192.0.2.10")
+                    header("X-Subject-Id", "55")
+                }
+            assertEquals(HttpStatusCode.TooManyRequests, blockedResponse.status)
+            val payload = json.decodeFromString<RateLimitError>(blockedResponse.bodyAsText())
+            assertEquals("subject", payload.type)
+            assertEquals(15, payload.retryAfterSeconds)
+        }
+    }
+
+    @Test
+    fun `metrics expose rate limit counters`() {
+        testApplication {
+            val clock = TestClock()
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val store = InMemoryBucketStore()
+            configureEnvironment {
+                put(CONFIG_INCLUDE_PATHS, "/test")
+                put(CONFIG_EXCLUDE_PATHS, "")
+                put(CONFIG_TRUST_PROXY, "true")
+                put(CONFIG_RETRY_AFTER, "25")
+                put(CONFIG_IP_ENABLED, "true")
+                put(CONFIG_IP_BURST, "1")
+                put(CONFIG_IP_RPS, "0")
+                put(CONFIG_IP_TTL, "60")
+                put(CONFIG_SUBJECT_ENABLED, "false")
+                put(CONFIG_SUBJECT_BURST, "1")
+                put(CONFIG_SUBJECT_RPS, "0")
+                put(CONFIG_SUBJECT_TTL, "60")
+            }
+            configureApplication(meterRegistry, store, clock)
+
+            client.get("/test") {
+                header("X-Forwarded-For", "203.0.113.77")
+            }
+            client.get("/test") {
+                header("X-Forwarded-For", "203.0.113.77")
+            }
+
+            val body = client.get("/metrics").bodyAsText()
+            assertTrue(body.lineSequence().any { line -> line.contains("af_rl_blocked_total") })
+            assertTrue(body.lineSequence().any { line -> line.contains("af_rl_retry_after_seconds_count") })
+        }
+    }
+
+    private fun ApplicationTestBuilder.configureEnvironment(block: MapApplicationConfig.() -> Unit) {
+        environment {
+            config = MapApplicationConfig().apply(block)
+        }
+    }
+
+    private fun ApplicationTestBuilder.configureApplication(
+        meterRegistry: PrometheusMeterRegistry,
+        store: InMemoryBucketStore,
+        clock: Clock,
+    ) {
+        application {
+            install(ContentNegotiation) {
+                json()
+            }
+            installAntifraudIntegration(
+                meterRegistry = meterRegistry,
+                store = store,
+                clock = clock,
+            )
+            routing {
+                get("/test") {
+                    call.respondText("OK")
+                }
+                get("/test/excluded") {
+                    call.respondText("OK")
+                }
+                get("/metrics") {
+                    call.respondText(meterRegistry.scrape())
+                }
+            }
+        }
+    }
+}
+
+private class TestClock : Clock {
+    override fun nowMillis(): Long = current
+
+    private var current: Long = 0L
+}
+
+@Serializable
+private data class RateLimitError(
+    val error: String,
+    val status: Int,
+    val requestId: String,
+    val type: String,
+    val retryAfterSeconds: Long,
+)


### PR DESCRIPTION
## Summary
- implement a RateLimitPlugin that enforces IP and subject token buckets, emits metrics, and returns unified JSON/Retry-After responses
- add antifraud bootstrap wiring that reads environment defaults, builds token buckets, and installs the plugin
- provide IP/subject key extractors and comprehensive tests covering limits, path filtering, and metrics exposure

## Testing
- ./gradlew clean build test detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbdb0a3a4883218584280eca8af5bb