### PR TITLE
Add admin antifraud IP management and rate limit integration

### DIFF
--- a/src/main/kotlin/com/example/giftsbot/antifraud/AdminAntifraudRoutes.kt
+++ b/src/main/kotlin/com/example/giftsbot/antifraud/AdminAntifraudRoutes.kt
@@ -1,0 +1,299 @@
+package com.example.giftsbot.antifraud
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.ContentTransformationException
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.header
+import io.ktor.server.request.receive
+import io.ktor.server.request.uri
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import org.slf4j.LoggerFactory
+
+private const val ADMIN_HEADER = "X-Admin-Token"
+private const val TYPE_RECENT = "recent"
+private const val TYPE_BANNED = "banned"
+private const val ERROR_UNAUTHORIZED = "unauthorized"
+private const val ERROR_FORBIDDEN = "forbidden"
+private const val ERROR_INVALID_REQUEST = "invalid_request"
+private const val ERROR_INVALID_IP = "invalid_ip"
+private const val ERROR_INVALID_TTL = "invalid_ttl"
+private const val ERROR_INVALID_TYPE = "invalid_type"
+private const val ERROR_INVALID_LIMIT = "invalid_limit"
+private const val ERROR_INVALID_SINCE = "invalid_since"
+private const val DEFAULT_LIST_LIMIT = 100
+private const val MIN_LIST_LIMIT = 1
+private const val MAX_LIST_LIMIT = 100
+private const val MIN_TTL_SECONDS = 0L
+private val logger = LoggerFactory.getLogger("AdminAntifraudRoutes")
+
+fun Route.adminAntifraudRoutes(
+    adminToken: String,
+    store: SuspiciousIpStore,
+    meterRegistry: MeterRegistry,
+    defaultBanTtlSeconds: Long,
+) {
+    val handler =
+        AdminAntifraudHandler(
+            adminToken = adminToken,
+            store = store,
+            metrics = AdminAntifraudMetrics(meterRegistry),
+            defaultBanTtlSeconds = defaultBanTtlSeconds,
+        )
+    route("/internal/antifraud/ip") {
+        post("/mark-suspicious") { handler.handleMarkSuspicious(call) }
+        post("/ban") { handler.handleBan(call) }
+        post("/unban") { handler.handleUnban(call) }
+        get("/list") { handler.handleList(call) }
+    }
+}
+
+private class AdminAntifraudHandler(
+    private val adminToken: String,
+    private val store: SuspiciousIpStore,
+    private val metrics: AdminAntifraudMetrics,
+    private val defaultBanTtlSeconds: Long,
+) {
+    suspend fun handleMarkSuspicious(call: ApplicationCall) {
+        if (!call.ensureAdminToken(adminToken)) {
+            return
+        }
+        val request = call.receivePayload<MarkSuspiciousRequest>()
+        if (request == null) {
+            return
+        }
+        val ip = request.ip.trim()
+        if (ip.isNotEmpty()) {
+            val entry = store.markSuspicious(ip, request.reason)
+            metrics.markSuspicious()
+            logger.info("suspicious mark success: requestId={}", call.callId ?: "-")
+            call.respond(entry)
+        } else {
+            call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_IP)
+        }
+    }
+
+    suspend fun handleBan(call: ApplicationCall) {
+        if (!call.ensureAdminToken(adminToken)) {
+            return
+        }
+        val request = call.receivePayload<BanIpRequest>()
+        if (request == null) {
+            return
+        }
+        val ip = request.ip.trim()
+        val ttl = request.ttlSeconds ?: defaultBanTtlSeconds
+        when {
+            ip.isEmpty() -> call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_IP)
+            ttl < MIN_TTL_SECONDS -> call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_TTL)
+            else -> {
+                val entry = store.ban(ip, ttl, request.reason)
+                metrics.markBan(entry.status)
+                logger.info("ban success: requestId={} status={}", call.callId ?: "-", entry.status)
+                call.respond(entry)
+            }
+        }
+    }
+
+    suspend fun handleUnban(call: ApplicationCall) {
+        if (!call.ensureAdminToken(adminToken)) {
+            return
+        }
+        val request = call.receivePayload<UnbanIpRequest>()
+        if (request == null) {
+            return
+        }
+        val ip = request.ip.trim()
+        if (ip.isNotEmpty()) {
+            val removed = store.unban(ip)
+            if (removed) {
+                metrics.markUnban()
+            }
+            logger.info("unban processed: requestId={} removed={}", call.callId ?: "-", removed)
+            call.respond(UnbanIpResponse(ok = removed))
+        } else {
+            call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_IP)
+        }
+    }
+
+    suspend fun handleList(call: ApplicationCall) {
+        if (!call.ensureAdminToken(adminToken)) {
+            return
+        }
+        val type = call.request.queryParameters["type"]?.lowercase() ?: TYPE_RECENT
+        val limit = resolveLimit(call) ?: return
+        val now = System.currentTimeMillis()
+        val response =
+            when (type) {
+                TYPE_RECENT -> {
+                    val sinceParam = resolveSince(call)
+                    if (sinceParam.valid) {
+                        store.listRecent(limit = limit, sinceMs = sinceParam.value, nowMs = now)
+                    } else {
+                        null
+                    }
+                }
+                TYPE_BANNED -> store.listBanned(limit = limit, nowMs = now)
+                else -> {
+                    call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_TYPE)
+                    null
+                }
+            }
+        if (response != null) {
+            logger.info("list success: requestId={} type={}", call.callId ?: "-", type)
+            call.respond(response)
+        }
+    }
+
+    private suspend fun resolveLimit(call: ApplicationCall): Int? {
+        val rawLimit = call.request.queryParameters["limit"]
+        if (rawLimit == null) {
+            return DEFAULT_LIST_LIMIT
+        }
+        val parsed = rawLimit.toIntOrNull()
+        return if (parsed != null && parsed in MIN_LIST_LIMIT..MAX_LIST_LIMIT) {
+            parsed
+        } else {
+            call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_LIMIT)
+            null
+        }
+    }
+
+    private suspend fun resolveSince(call: ApplicationCall): SinceParam {
+        val rawSince = call.request.queryParameters["sinceMs"]
+        return if (rawSince == null) {
+            SinceParam(value = null, valid = true)
+        } else {
+            val parsed = rawSince.toLongOrNull()
+            if (parsed == null || parsed < 0) {
+                call.respondError(HttpStatusCode.BadRequest, ERROR_INVALID_SINCE)
+                SinceParam(value = null, valid = false)
+            } else {
+                SinceParam(value = parsed, valid = true)
+            }
+        }
+    }
+}
+
+private data class SinceParam(
+    val value: Long?,
+    val valid: Boolean,
+)
+
+private class AdminAntifraudMetrics(
+    registry: MeterRegistry,
+) {
+    private val markCounter: Counter = Counter.builder("af_ip_suspicious_mark_total").register(registry)
+    private val banTempCounter: Counter =
+        Counter
+            .builder("af_ip_ban_total")
+            .tag("type", "temp")
+            .register(registry)
+    private val banPermCounter: Counter =
+        Counter
+            .builder("af_ip_ban_total")
+            .tag("type", "perm")
+            .register(registry)
+    private val unbanCounter: Counter = Counter.builder("af_ip_unban_total").register(registry)
+
+    fun markSuspicious() {
+        markCounter.increment()
+    }
+
+    fun markBan(status: IpStatus) {
+        when (status) {
+            IpStatus.TEMP_BANNED -> banTempCounter.increment()
+            IpStatus.PERM_BANNED -> banPermCounter.increment()
+            IpStatus.SUSPICIOUS -> {}
+        }
+    }
+
+    fun markUnban() {
+        unbanCounter.increment()
+    }
+}
+
+private suspend fun ApplicationCall.ensureAdminToken(adminToken: String): Boolean {
+    val provided = request.header(ADMIN_HEADER)
+    return when {
+        provided == null -> {
+            logger.warn("admin auth missing: requestId={}", callId ?: "-")
+            respondError(HttpStatusCode.Unauthorized, ERROR_UNAUTHORIZED)
+            false
+        }
+        provided != adminToken -> {
+            logger.warn("admin auth mismatch: requestId={}", callId ?: "-")
+            respondError(HttpStatusCode.Forbidden, ERROR_FORBIDDEN)
+            false
+        }
+        else -> true
+    }
+}
+
+private suspend inline fun <reified T> ApplicationCall.receivePayload(): T? =
+    try {
+        receive()
+    } catch (cause: CancellationException) {
+        throw cause
+    } catch (cause: ContentTransformationException) {
+        logger.warn("invalid admin request body: requestId={} uri={}", callId ?: "-", request.uri, cause)
+        respondError(HttpStatusCode.BadRequest, ERROR_INVALID_REQUEST)
+        null
+    } catch (cause: SerializationException) {
+        logger.warn("invalid admin request body: requestId={} uri={}", callId ?: "-", request.uri, cause)
+        respondError(HttpStatusCode.BadRequest, ERROR_INVALID_REQUEST)
+        null
+    }
+
+private suspend fun ApplicationCall.respondError(
+    status: HttpStatusCode,
+    error: String,
+) {
+    respond(
+        status,
+        AdminAntifraudErrorResponse(
+            error = error,
+            status = status.value,
+            requestId = callId,
+        ),
+    )
+}
+
+@Serializable
+data class MarkSuspiciousRequest(
+    val ip: String,
+    val reason: String? = null,
+)
+
+@Serializable
+data class BanIpRequest(
+    val ip: String,
+    val ttlSeconds: Long? = null,
+    val reason: String? = null,
+)
+
+@Serializable
+data class UnbanIpRequest(
+    val ip: String,
+)
+
+@Serializable
+data class UnbanIpResponse(
+    val ok: Boolean,
+)
+
+@Serializable
+data class AdminAntifraudErrorResponse(
+    val error: String,
+    val status: Int,
+    val requestId: String?,
+)

--- a/src/main/kotlin/com/example/giftsbot/antifraud/SuspiciousIpStore.kt
+++ b/src/main/kotlin/com/example/giftsbot/antifraud/SuspiciousIpStore.kt
@@ -1,0 +1,249 @@
+package com.example.giftsbot.antifraud
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+import java.util.concurrent.ConcurrentHashMap
+
+@Serializable
+enum class IpStatus {
+    SUSPICIOUS,
+    TEMP_BANNED,
+    PERM_BANNED,
+}
+
+@Serializable
+data class IpEntry(
+    val ip: String,
+    val status: IpStatus,
+    val reason: String?,
+    val createdAtMs: Long,
+    val expiresAtMs: Long?,
+    val lastSeenMs: Long,
+)
+
+interface SuspiciousIpStore {
+    fun markSuspicious(
+        ip: String,
+        reason: String?,
+        nowMs: Long = System.currentTimeMillis(),
+    ): IpEntry
+
+    fun ban(
+        ip: String,
+        ttlSeconds: Long?,
+        reason: String?,
+        nowMs: Long = System.currentTimeMillis(),
+    ): IpEntry
+
+    fun unban(
+        ip: String,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Boolean
+
+    fun isBanned(
+        ip: String,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Pair<Boolean, Long?>
+
+    fun listRecent(
+        limit: Int = 100,
+        sinceMs: Long? = null,
+        nowMs: Long = System.currentTimeMillis(),
+    ): List<IpEntry>
+
+    fun listBanned(
+        limit: Int = 100,
+        nowMs: Long = System.currentTimeMillis(),
+    ): List<IpEntry>
+}
+
+private const val MAX_LIST_LIMIT = 100
+private const val MIN_LIST_LIMIT = 1
+private const val MILLIS_IN_SECOND = 1000L
+private const val PERMANENT_TTL_SECONDS = 0L
+
+class InMemorySuspiciousIpStore : SuspiciousIpStore {
+    private val entries = ConcurrentHashMap<String, IpEntry>()
+    private val locks = ConcurrentHashMap<String, Mutex>()
+
+    override fun markSuspicious(
+        ip: String,
+        reason: String?,
+        nowMs: Long,
+    ): IpEntry =
+        withIpLock(ip) {
+            val existing = activeEntry(ip, nowMs)
+            val createdAt = existing?.createdAtMs ?: nowMs
+            val updatedReason = reason ?: existing?.reason
+            val entry =
+                IpEntry(
+                    ip = ip,
+                    status = IpStatus.SUSPICIOUS,
+                    reason = updatedReason,
+                    createdAtMs = createdAt,
+                    expiresAtMs = null,
+                    lastSeenMs = nowMs,
+                )
+            entries[ip] = entry
+            entry
+        }
+
+    override fun ban(
+        ip: String,
+        ttlSeconds: Long?,
+        reason: String?,
+        nowMs: Long,
+    ): IpEntry =
+        withIpLock(ip) {
+            val existing = activeEntry(ip, nowMs)
+            val createdAt = existing?.createdAtMs ?: nowMs
+            val sanitizedTtl = (ttlSeconds ?: PERMANENT_TTL_SECONDS).coerceAtLeast(PERMANENT_TTL_SECONDS)
+            val status = if (sanitizedTtl == PERMANENT_TTL_SECONDS) IpStatus.PERM_BANNED else IpStatus.TEMP_BANNED
+            val expiresAt = if (status == IpStatus.TEMP_BANNED) nowMs + sanitizedTtl * MILLIS_IN_SECOND else null
+            val entry =
+                IpEntry(
+                    ip = ip,
+                    status = status,
+                    reason = reason ?: existing?.reason,
+                    createdAtMs = createdAt,
+                    expiresAtMs = expiresAt,
+                    lastSeenMs = nowMs,
+                )
+            entries[ip] = entry
+            entry
+        }
+
+    override fun unban(
+        ip: String,
+        nowMs: Long,
+    ): Boolean =
+        withIpLock(ip) {
+            val existing = entries[ip]
+            if (existing == null) {
+                return@withIpLock false
+            }
+            if (isExpired(existing, nowMs)) {
+                entries.remove(ip)
+                return@withIpLock true
+            }
+            entries.remove(ip)
+            true
+        }
+
+    override fun isBanned(
+        ip: String,
+        nowMs: Long,
+    ): Pair<Boolean, Long?> =
+        withIpLock(ip) {
+            val entry = activeEntry(ip, nowMs) ?: return@withIpLock false to null
+            val updated = entry.copy(lastSeenMs = nowMs)
+            entries[ip] = updated
+            when (updated.status) {
+                IpStatus.PERM_BANNED -> true to null
+                IpStatus.TEMP_BANNED -> true to updated.remainingSeconds(nowMs)
+                IpStatus.SUSPICIOUS -> false to null
+            }
+        }
+
+    override fun listRecent(
+        limit: Int,
+        sinceMs: Long?,
+        nowMs: Long,
+    ): List<IpEntry> {
+        cleanupExpired(nowMs)
+        val effectiveLimit = limit.coerceIn(MIN_LIST_LIMIT, MAX_LIST_LIMIT)
+        return entries
+            .values
+            .asSequence()
+            .filter { entry -> sinceMs == null || entry.createdAtMs >= sinceMs }
+            .sortedByDescending { entry -> entry.createdAtMs }
+            .take(effectiveLimit)
+            .toList()
+    }
+
+    override fun listBanned(
+        limit: Int,
+        nowMs: Long,
+    ): List<IpEntry> {
+        cleanupExpired(nowMs)
+        val effectiveLimit = limit.coerceIn(MIN_LIST_LIMIT, MAX_LIST_LIMIT)
+        val activeBans =
+            entries.values.filter { entry ->
+                when (entry.status) {
+                    IpStatus.TEMP_BANNED -> entry.expiresAtMs != null
+                    IpStatus.PERM_BANNED -> true
+                    IpStatus.SUSPICIOUS -> false
+                }
+            }
+        val sortedTemporary =
+            activeBans
+                .asSequence()
+                .filter { entry -> entry.status == IpStatus.TEMP_BANNED }
+                .sortedBy { entry -> entry.expiresAtMs }
+                .toList()
+        val sortedPermanent =
+            activeBans
+                .asSequence()
+                .filter { entry -> entry.status == IpStatus.PERM_BANNED }
+                .sortedBy { entry -> entry.createdAtMs }
+                .toList()
+        return (sortedTemporary + sortedPermanent).take(effectiveLimit)
+    }
+
+    private fun cleanupExpired(nowMs: Long) {
+        entries.entries.removeIf { (_, entry) -> isExpired(entry, nowMs) }
+    }
+
+    private fun activeEntry(
+        ip: String,
+        nowMs: Long,
+    ): IpEntry? {
+        val entry = entries[ip]
+        return when {
+            entry == null -> null
+            isExpired(entry, nowMs) -> {
+                entries.remove(ip)
+                null
+            }
+            else -> entry
+        }
+    }
+
+    private fun isExpired(
+        entry: IpEntry,
+        nowMs: Long,
+    ): Boolean =
+        when (entry.status) {
+            IpStatus.TEMP_BANNED -> entry.expiresAtMs?.let { expiresAt -> expiresAt <= nowMs } ?: true
+            IpStatus.PERM_BANNED, IpStatus.SUSPICIOUS -> false
+        }
+
+    private fun <T> withIpLock(
+        ip: String,
+        action: () -> T,
+    ): T {
+        val mutex = locks.computeIfAbsent(ip) { Mutex() }
+        return runBlocking {
+            val result = mutex.withLock { action() }
+            if (!mutex.isLocked && !entries.containsKey(ip)) {
+                locks.remove(ip, mutex)
+            }
+            result
+        }
+    }
+}
+
+private fun IpEntry.remainingSeconds(nowMs: Long): Long? {
+    val expiresAt = expiresAtMs ?: return null
+    val remaining = expiresAt - nowMs
+    return when {
+        remaining <= 0 -> 0L
+        else -> {
+            val quotient = remaining / MILLIS_IN_SECOND
+            val remainder = remaining % MILLIS_IN_SECOND
+            if (remainder == 0L) quotient else quotient + 1
+        }
+    }
+}

--- a/src/test/kotlin/com/example/giftsbot/antifraud/AdminAntifraudRoutesTest.kt
+++ b/src/test/kotlin/com/example/giftsbot/antifraud/AdminAntifraudRoutesTest.kt
@@ -1,0 +1,296 @@
+package com.example.giftsbot.antifraud
+
+import com.example.giftsbot.antifraud.store.InMemoryBucketStore
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+private const val CONFIG_INCLUDE_PATHS = "app.antifraud.rl.includePaths"
+private const val CONFIG_EXCLUDE_PATHS = "app.antifraud.rl.excludePaths"
+private const val CONFIG_TRUST_PROXY = "app.antifraud.rl.trustProxy"
+private const val CONFIG_RETRY_AFTER = "app.antifraud.rl.retryAfter"
+private const val CONFIG_IP_ENABLED = "app.antifraud.rl.ip.enabled"
+private const val CONFIG_IP_BURST = "app.antifraud.rl.ip.capacity"
+private const val CONFIG_IP_RPS = "app.antifraud.rl.ip.rps"
+private const val CONFIG_IP_TTL = "app.antifraud.rl.ip.ttlSeconds"
+private const val CONFIG_SUBJECT_ENABLED = "app.antifraud.rl.subject.enabled"
+private const val CONFIG_SUBJECT_BURST = "app.antifraud.rl.subject.capacity"
+private const val CONFIG_SUBJECT_RPS = "app.antifraud.rl.subject.rps"
+private const val CONFIG_SUBJECT_TTL = "app.antifraud.rl.subject.ttlSeconds"
+private const val CONFIG_ADMIN_TOKEN = "app.antifraud.admin.token"
+private const val CONFIG_BAN_TTL = "app.antifraud.ban.defaultTtlSeconds"
+private const val ADMIN_HEADER = "X-Admin-Token"
+private const val ADMIN_TOKEN_VALUE = "secret-token"
+private const val METRIC_SUSPICIOUS = "af_ip_suspicious_mark_total"
+private const val METRIC_TEMP_BAN = "af_ip_ban_total{type=\"temp\"}"
+private const val METRIC_PERM_BAN = "af_ip_ban_total{type=\"perm\"}"
+private const val METRIC_UNBAN = "af_ip_unban_total"
+private const val METRIC_FORBIDDEN = "af_ip_forbidden_total"
+
+class AdminAntifraudRoutesTest {
+    private val json = Json { ignoreUnknownKeys = false }
+
+    @Test
+    fun `admin routes manage suspicious ips and bans`() {
+        testApplication {
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val bucketStore = InMemoryBucketStore()
+            val suspiciousStore = InMemorySuspiciousIpStore()
+            configureEnvironment {
+                put(CONFIG_INCLUDE_PATHS, "/protected")
+                put(CONFIG_EXCLUDE_PATHS, "")
+                put(CONFIG_TRUST_PROXY, "true")
+                put(CONFIG_RETRY_AFTER, "60")
+                put(CONFIG_IP_ENABLED, "true")
+                put(CONFIG_IP_BURST, "5")
+                put(CONFIG_IP_RPS, "1")
+                put(CONFIG_IP_TTL, "60")
+                put(CONFIG_SUBJECT_ENABLED, "false")
+                put(CONFIG_SUBJECT_BURST, "1")
+                put(CONFIG_SUBJECT_RPS, "0")
+                put(CONFIG_SUBJECT_TTL, "60")
+                put(CONFIG_ADMIN_TOKEN, ADMIN_TOKEN_VALUE)
+                put(CONFIG_BAN_TTL, "120")
+            }
+            configureApplication(meterRegistry, bucketStore, suspiciousStore)
+
+            assertUnauthorizedAccess()
+
+            val suspiciousIp = "198.51.100.10"
+            markSuspiciousIp(suspiciousIp, reason = "suspicious")
+            assertRecentContains(suspiciousIp)
+
+            val tempBannedIp = "198.51.100.11"
+            banIp(tempBannedIp, ttlSeconds = 10, reason = "temp")
+            assertTempBanEnforced(tempBannedIp)
+
+            val permBannedIp = "198.51.100.12"
+            banIp(permBannedIp, ttlSeconds = 0, reason = "perm")
+            assertPermBanEnforced(permBannedIp)
+
+            unbanIp(permBannedIp)
+            assertPermAccessRestored(permBannedIp)
+            assertBannedList(tempBannedIp, permBannedIp)
+
+            assertMetrics()
+            assertLazyEviction(suspiciousStore)
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.assertUnauthorizedAccess() {
+        val payload = MarkSuspiciousRequest(ip = "203.0.113.10")
+        val response =
+            client.post("/internal/antifraud/ip/mark-suspicious") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(json.encodeToString(MarkSuspiciousRequest.serializer(), payload))
+            }
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        val body = json.decodeFromString(AdminAntifraudErrorResponse.serializer(), response.bodyAsText())
+        assertEquals("unauthorized", body.error)
+
+        val forbidden =
+            client.post("/internal/antifraud/ip/mark-suspicious") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(ADMIN_HEADER, "wrong")
+                setBody(json.encodeToString(MarkSuspiciousRequest.serializer(), payload))
+            }
+        assertEquals(HttpStatusCode.Forbidden, forbidden.status)
+        val forbiddenBody = json.decodeFromString(AdminAntifraudErrorResponse.serializer(), forbidden.bodyAsText())
+        assertEquals("forbidden", forbiddenBody.error)
+    }
+
+    private suspend fun ApplicationTestBuilder.markSuspiciousIp(
+        ip: String,
+        reason: String?,
+    ) {
+        val request = MarkSuspiciousRequest(ip = ip, reason = reason)
+        val response =
+            client.post("/internal/antifraud/ip/mark-suspicious") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(ADMIN_HEADER, ADMIN_TOKEN_VALUE)
+                setBody(json.encodeToString(MarkSuspiciousRequest.serializer(), request))
+            }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val entry = json.decodeFromString(IpEntry.serializer(), response.bodyAsText())
+        assertEquals(IpStatus.SUSPICIOUS, entry.status)
+        assertEquals(reason, entry.reason)
+    }
+
+    private suspend fun ApplicationTestBuilder.assertRecentContains(ip: String) {
+        val response =
+            client.get("/internal/antifraud/ip/list") {
+                header(ADMIN_HEADER, ADMIN_TOKEN_VALUE)
+            }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val entries = json.decodeFromString(ListSerializer(IpEntry.serializer()), response.bodyAsText())
+        assertTrue(entries.any { entry -> entry.ip == ip })
+    }
+
+    private suspend fun ApplicationTestBuilder.banIp(
+        ip: String,
+        ttlSeconds: Long,
+        reason: String?,
+    ) {
+        val request = BanIpRequest(ip = ip, ttlSeconds = ttlSeconds, reason = reason)
+        val response =
+            client.post("/internal/antifraud/ip/ban") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(ADMIN_HEADER, ADMIN_TOKEN_VALUE)
+                setBody(json.encodeToString(BanIpRequest.serializer(), request))
+            }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val entry = json.decodeFromString(IpEntry.serializer(), response.bodyAsText())
+        if (ttlSeconds == 0L) {
+            assertEquals(IpStatus.PERM_BANNED, entry.status)
+            assertNull(entry.expiresAtMs)
+        } else {
+            assertEquals(IpStatus.TEMP_BANNED, entry.status)
+            assertNotNull(entry.expiresAtMs)
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.assertTempBanEnforced(ip: String) {
+        val response =
+            client.get("/protected") {
+                header("X-Forwarded-For", ip)
+            }
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        val body = json.decodeFromString(BannedIpError.serializer(), response.bodyAsText())
+        assertEquals("ip_banned", body.error)
+        assertNotNull(body.retryAfterSeconds)
+    }
+
+    private suspend fun ApplicationTestBuilder.assertPermBanEnforced(ip: String) {
+        val response =
+            client.get("/protected") {
+                header("X-Forwarded-For", ip)
+            }
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        val body = json.decodeFromString(BannedIpError.serializer(), response.bodyAsText())
+        assertEquals("ip_banned", body.error)
+        assertNull(body.retryAfterSeconds)
+    }
+
+    private suspend fun ApplicationTestBuilder.unbanIp(ip: String) {
+        val request = UnbanIpRequest(ip = ip)
+        val response =
+            client.post("/internal/antifraud/ip/unban") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(ADMIN_HEADER, ADMIN_TOKEN_VALUE)
+                setBody(json.encodeToString(UnbanIpRequest.serializer(), request))
+            }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.decodeFromString(UnbanIpResponse.serializer(), response.bodyAsText())
+        assertTrue(body.ok)
+    }
+
+    private suspend fun ApplicationTestBuilder.assertPermAccessRestored(ip: String) {
+        val response =
+            client.get("/protected") {
+                header("X-Forwarded-For", ip)
+            }
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    private suspend fun ApplicationTestBuilder.assertBannedList(
+        tempIp: String,
+        removedIp: String,
+    ) {
+        val response =
+            client.get("/internal/antifraud/ip/list?type=banned") {
+                header(ADMIN_HEADER, ADMIN_TOKEN_VALUE)
+            }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val entries = json.decodeFromString(ListSerializer(IpEntry.serializer()), response.bodyAsText())
+        assertTrue(entries.any { entry -> entry.ip == tempIp })
+        assertFalse(entries.any { entry -> entry.ip == removedIp })
+    }
+
+    private suspend fun ApplicationTestBuilder.assertMetrics() {
+        val response = client.get("/metrics")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.lineSequence().any { line -> line.contains(METRIC_SUSPICIOUS) })
+        assertTrue(body.lineSequence().any { line -> line.contains(METRIC_TEMP_BAN) })
+        assertTrue(body.lineSequence().any { line -> line.contains(METRIC_PERM_BAN) })
+        assertTrue(body.lineSequence().any { line -> line.contains(METRIC_UNBAN) })
+        assertTrue(body.lineSequence().any { line -> line.contains(METRIC_FORBIDDEN) })
+    }
+
+    private fun assertLazyEviction(store: SuspiciousIpStore) {
+        val baseTime = 1_000L
+        val ip = "198.51.100.99"
+        val created = store.ban(ip, ttlSeconds = 1, reason = "expiring", nowMs = baseTime)
+        assertEquals(IpStatus.TEMP_BANNED, created.status)
+        val (active, _) = store.isBanned(ip, nowMs = baseTime)
+        assertTrue(active)
+        val (expired, _) = store.isBanned(ip, nowMs = baseTime + 5_000)
+        assertFalse(expired)
+        val remaining = store.listBanned(nowMs = baseTime + 5_000)
+        assertTrue(remaining.none { entry -> entry.ip == ip })
+    }
+
+    private fun ApplicationTestBuilder.configureEnvironment(block: MapApplicationConfig.() -> Unit) {
+        environment {
+            config = MapApplicationConfig().apply(block)
+        }
+    }
+
+    private fun ApplicationTestBuilder.configureApplication(
+        meterRegistry: PrometheusMeterRegistry,
+        bucketStore: InMemoryBucketStore,
+        suspiciousStore: SuspiciousIpStore,
+    ) {
+        application {
+            install(ContentNegotiation) {
+                json()
+            }
+            installAntifraudIntegration(
+                meterRegistry = meterRegistry,
+                store = bucketStore,
+                suspiciousIpStore = suspiciousStore,
+            )
+            routing {
+                get("/protected") {
+                    call.respondText("OK")
+                }
+                get("/metrics") {
+                    call.respondText(meterRegistry.scrape())
+                }
+            }
+        }
+    }
+
+    @Serializable
+    private data class BannedIpError(
+        val error: String,
+        val status: Int,
+        val requestId: String,
+        val retryAfterSeconds: Long?,
+    )
+}


### PR DESCRIPTION
## Summary
- add an in-memory suspicious IP store with lazy TTL eviction
- expose admin antifraud routes and metrics for suspicious IP operations
- enforce suspicious IP bans before token bucket rate limiting

## Testing
- ./gradlew clean build test detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbeb1598b8832185953a964469fa51